### PR TITLE
✨ add open cluster management control plane type

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -179,7 +179,3 @@ func ConditionReconcileError(err error) ControlPlaneCondition {
 		Message:            err.Error(),
 	}
 }
-
-func myAppend(list *[]string, value string) {
-	*list = append(*list, value)
-}

--- a/api/v1alpha1/controlplane_types.go
+++ b/api/v1alpha1/controlplane_types.go
@@ -17,14 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ControlPlaneSpec defines the desired state of ControlPlane
 type ControlPlaneSpec struct {
-	Backend BackendDBType `json:"backend,omitempty" validate:"required,BackendDBType"`
+	Type    ControlPlaneType `json:"type,omitempty"`
+	Backend BackendDBType    `json:"backend,omitempty"`
 }
 
 // ControlPlaneStatus defines the observed state of ControlPlane
@@ -57,6 +56,7 @@ type ControlPlaneList struct {
 	Items           []ControlPlane `json:"items"`
 }
 
+// +kubebuilder:validation:Enum=shared;dedicated
 type BackendDBType string
 
 const (
@@ -64,13 +64,14 @@ const (
 	BackendDBTypeDedicated BackendDBType = "dedicated"
 )
 
-func (b BackendDBType) Validate() error {
-	switch b {
-	case BackendDBTypeShared, BackendDBTypeDedicated:
-		return nil
-	}
-	return fmt.Errorf("invalid value for BackendDBType: %s", string(b))
-}
+// +kubebuilder:validation:Enum=k8s;ocm;vcluster
+type ControlPlaneType string
+
+const (
+	ControlPlaneTypeK8S      ControlPlaneType = "k8s"
+	ControlPlaneTypeOCM      ControlPlaneType = "ocm"
+	ControlPlaneTypeVCluster ControlPlaneType = "vcluster"
+)
 
 func init() {
 	SchemeBuilder.Register(&ControlPlane{}, &ControlPlaneList{})

--- a/cmd/cmupdate/main.go
+++ b/cmd/cmupdate/main.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/kubestellar/kubeflex/pkg/reconcilers/ocm"
+	"github.com/kubestellar/kubeflex/pkg/util"
+)
+
+const (
+	kubeconfigSecret    = "multicluster-controlplane-kubeconfig"
+	kubeconfigSecretKey = "kubeconfig"
+	configMapName       = "cluster-info"
+	keyToUpdate         = "kubeconfig"
+	kubePublicNamespace = "kube-public"
+	controlPlaneType    = "ocm"
+	clusterName         = ""
+	baseURL             = "https://kubeflex-control-plane"
+)
+
+// The CM update updates the cluster-info config map in a OCM control plane
+// for setting the internal server value that can be used by other kind servers
+// on the same docker network
+func main() {
+	kconfig := flag.String("kconfig", "", "path to the kubeconfig file")
+	flag.Parse()
+	namespace := os.Getenv("KUBERNETES_NAMESPACE")
+	if namespace == "" {
+		log.Fatal("Namespace not found.")
+	} else {
+		log.Printf("Current Namespace: %s", namespace)
+	}
+	ctx := context.TODO()
+
+	// Create the Kubernetes clientset
+	config, err := clientcmd.BuildConfigFromFlags("", *kconfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// wait for ocm deployment to be available
+	if err := util.WaitForDeploymentReady(*clientset,
+		util.OCMServerDeploymentName,
+		namespace); err != nil {
+
+		log.Fatalf("Error waiting for deployment to become ready: %s", err)
+	}
+
+	nodePort, err := retrieveServiceNodePort(clientset, ocm.ServiceName, namespace, ctx)
+	if err != nil {
+		log.Fatalf("Error looking up the node port from ocm service: %s", err)
+	}
+
+	configData, err := retrieveHostedServerKubeConfig(clientset, namespace, ctx)
+	if err != nil {
+		log.Fatalf("Error getting kubeconfig for hosted server: %s", err)
+	}
+
+	clientForHostedServer, err := createClientForHostedServer(configData)
+	if err != nil {
+		log.Fatalf("Error getting client for for hosted server: %s", err)
+	}
+
+	configMap, err := retrieveConfigMap(clientForHostedServer, ctx)
+	if err != nil {
+		log.Fatalf("Error retrieving the cluster-info map for for hosted server: %s", err)
+	}
+
+	serverURL := fmt.Sprintf("%s:%d", baseURL, nodePort)
+	updatedConfigMap := updateConfigMap(configMap, clusterName, keyToUpdate, serverURL)
+
+	err = updateConfigMapValue(clientForHostedServer, ctx, updatedConfigMap)
+	if err != nil {
+		log.Fatalf("Error updating the cluster-info map for for hosted server: %s", err)
+	}
+
+	log.Println("ConfigMap updated successfully!")
+}
+
+func retrieveServiceNodePort(clientset *kubernetes.Clientset, name, ns string, ctx context.Context) (int32, error) {
+	svc, err := clientset.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return -1, err
+	}
+	for _, port := range svc.Spec.Ports {
+		if port.Name == "https" {
+			return port.NodePort, nil
+		}
+	}
+	return -1, fmt.Errorf("port not found")
+}
+
+func retrieveHostedServerKubeConfig(clientset *kubernetes.Clientset, ns string, ctx context.Context) ([]byte, error) {
+	secret, err := clientset.CoreV1().Secrets(ns).Get(ctx, kubeconfigSecret, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	kData, ok := secret.Data[kubeconfigSecretKey]
+	if !ok {
+		return nil, fmt.Errorf("key %s not found in kubeconfig secret", kubeconfigSecretKey)
+	}
+	return kData, nil
+}
+
+func createClientForHostedServer(configData []byte) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.NewClientConfigFromBytes(configData)
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig, err := config.ClientConfig()
+	restConfig.Host = "multicluster-controlplane.cp2-system:9444"
+	if err != nil {
+		return nil, err
+	}
+
+	return kubernetes.NewForConfig(restConfig)
+}
+
+func retrieveConfigMap(clientset *kubernetes.Clientset, ctx context.Context) (*corev1.ConfigMap, error) {
+	configMap, err := clientset.CoreV1().ConfigMaps(kubePublicNamespace).Get(ctx, configMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return configMap, nil
+}
+
+func updateConfigMap(configMap *corev1.ConfigMap, clusterName, keyToUpdate, newServerValue string) *corev1.ConfigMap {
+	configData := configMap.Data[keyToUpdate]
+	config, err := clientcmd.Load([]byte(configData))
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// Update the server value in the Config object
+	config.Clusters[clusterName].Server = newServerValue
+
+	updatedConfigData, err := clientcmd.Write(*config)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// Create a copy of the original config map and update its data field
+	updatedConfigMap := configMap.DeepCopy()
+	updatedConfigMap.Data[keyToUpdate] = string(updatedConfigData)
+
+	return updatedConfigMap
+}
+
+func updateConfigMapValue(clientset *kubernetes.Clientset, ctx context.Context, updatedConfigMap *corev1.ConfigMap) error {
+	_, err := clientset.CoreV1().ConfigMaps(kubePublicNamespace).Update(ctx, updatedConfigMap, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/kflex/init/cluster/kind.go
+++ b/cmd/kflex/init/cluster/kind.go
@@ -75,6 +75,8 @@ func createKindInstance(name string) error {
 	// create a template for the kind config file
 	tmpl := template.Must(template.New("kind-config").Parse(`kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: dual
 nodes:
 - role: control-plane
   kubeadmConfigPatches:

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
 	cr "github.com/kubestellar/kubeflex/cmd/kflex/create"
 	cont "github.com/kubestellar/kubeflex/cmd/kflex/ctx"
@@ -39,6 +40,12 @@ var kubeconfig string
 var verbosity int
 var Version string
 var BuildDate string
+var CType string
+var BkType string
+
+// defaults
+const BKTypeDefault = string(tenancyv1alpha1.BackendDBTypeShared)
+const CTypeDefault = string(tenancyv1alpha1.ControlPlaneTypeK8S)
 
 var rootCmd = &cobra.Command{
 	Use:   "kflex",
@@ -90,7 +97,13 @@ var createCmd = &cobra.Command{
 				Kubeconfig: kubeconfig,
 			},
 		}
-		cp.Create()
+		if CType == "" {
+			CType = CTypeDefault
+		}
+		if BkType == "" {
+			BkType = BKTypeDefault
+		}
+		cp.Create(CType, BkType)
 	},
 }
 
@@ -144,6 +157,8 @@ func init() {
 
 	createCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to kubeconfig file")
 	createCmd.Flags().IntVarP(&verbosity, "verbosity", "v", 0, "log level") // TODO - figure out how to inject verbosity
+	createCmd.Flags().StringVarP(&CType, "type", "t", "", "type of control plane: k8s|ocm|vcluster")
+	createCmd.Flags().StringVarP(&BkType, "backend-type", "b", "", "backend DB sharing: shared|dedicated")
 
 	deleteCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to kubeconfig file")
 	deleteCmd.Flags().IntVarP(&verbosity, "verbosity", "v", 0, "log level") // TODO - figure out how to inject verbosity

--- a/config/crd/bases/tenancy.kflex.kubestellar.org_controlplanes.yaml
+++ b/config/crd/bases/tenancy.kflex.kubestellar.org_controlplanes.yaml
@@ -48,6 +48,15 @@ spec:
             description: ControlPlaneSpec defines the desired state of ControlPlane
             properties:
               backend:
+                enum:
+                - shared
+                - dedicated
+                type: string
+              type:
+                enum:
+                - k8s
+                - ocm
+                - vcluster
                 type: string
             type: object
           status:

--- a/config/samples/tenancy_v1alpha1_controlplane.yaml
+++ b/config/samples/tenancy_v1alpha1_controlplane.yaml
@@ -9,4 +9,5 @@ metadata:
     app.kubernetes.io/created-by: kubeflex
   name: cp1
 spec:
+  type: k8s
   backend: shared

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -29,7 +29,9 @@ kubectl get secrets -n ${NAMESPACE} ${NAME} -o jsonpath='{.data.apiserver\.crt}'
 NAMESPACE= # your namespace
 NAME= # pod name
 CONTAINER= # container name
-kubectl debug -n ${NAMESPACE} -it ${NAME} --image=busybox:1.28 --target=${CONTAINER}
+IMAGE=ubuntu:latest
+kubectl debug -n ${NAMESPACE} -it ${NAME} --image=${IMAGE} --target=${CONTAINER} -- bash
+# e.g. kubectl debug -n ${NAMESPACE} -it ${NAME} --image=curlimages/curl:8.1.2 --target=${CONTAINER} -- sh
 ```
 
 ### Getting all the command args for a process
@@ -42,4 +44,19 @@ cat /proc/<pid>/cmdline | sed -e "s/\x00/ /g"; echo
 
 ```shell
 helm install test -n kubeflex-system --create-namespace oci://ghcr.io/kubestellar/kubeflex/chart/kubeflex-operator --version v0.1.0
+```
+
+### How to communicate between kind clusters on the same node
+
+One approach that is independent of local machine IP is to use the internal DNS address of
+docker containers. The address is the name of the docker container. For kubflex that
+address is `kubeflex-control-plane`. For example, if I have a nodeport service on 
+`kubeflex-control-plane` with port 30080 and I want to access it from another kind cluster
+the internal address to use is `https://kubeflex-control-plane:30080`
+
+### Commands to package and push a chart to a OCI registry
+
+```shell
+helm package charts/multicluster-controlplane
+helm push multicluster-controlplane-chart-0.1.0.tgz oci://quay.io/pdettori
 ```

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -54,9 +54,36 @@ address is `kubeflex-control-plane`. For example, if I have a nodeport service o
 `kubeflex-control-plane` with port 30080 and I want to access it from another kind cluster
 the internal address to use is `https://kubeflex-control-plane:30080`
 
+### Commands to build ocm from fork
+
+```shell
+git clone https://github.com/pdettori/multicluster-controlplane.git
+cd multicluster-controlplane
+git checkout kubeflex
+make image
+docker tag quay.io/open-cluster-management/multicluster-controlplane:latest quay.io/pdettori/multicluster-controlplane:latest
+docker push quay.io/pdettori/multicluster-controlplane:latest
+```
 ### Commands to package and push a chart to a OCI registry
+
+First clone and build image as explained in [Commands to build ocm from fork](#commands-to-build-ocm-from-fork), then:
 
 ```shell
 helm package charts/multicluster-controlplane
 helm push multicluster-controlplane-chart-0.1.0.tgz oci://quay.io/pdettori
 ```
+
+### Commands to build and load locally the cmupdate image (for testing)
+
+```shell
+ko build --local --push=false -B ./cmd/cmupdate -t $(git rev-parse --short HEAD) --platform linux/arm64
+kind load docker-image ko.local/cmupdate:$(git rev-parse --short HEAD) --name kubeflex
+```
+### Commands to build and push the cmupdate image
+
+```shell
+ko build --local --push=false -B ./cmd/cmupdate -t latest --platform linux/amd64,linux/arm64 
+docker tag ko.local/cmupdate:latest quay.io/pdettori/cmupdate:latest
+docker push quay.io/pdettori/cmupdate:latest
+```
+

--- a/pkg/certs/kconfig_gen.go
+++ b/pkg/certs/kconfig_gen.go
@@ -27,12 +27,11 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/kubestellar/kubeflex/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
-	"github.com/kubestellar/kubeflex/pkg/util"
 )
 
 type ConfigTarget int
@@ -44,7 +43,6 @@ const (
 	AdminCN          = "kubernetes-admin"
 	Organization     = "system:masters"
 	ContrCMCN        = "system:kube-controller-manager"
-	AdminConfSecret  = "admin-kubeconfig"
 	CMConfSecret     = "cm-kubeconfig"
 	ConfSecretKey    = "kubeconfig"
 )
@@ -98,7 +96,7 @@ func (c *ConfigGen) generateConfigCerts() error {
 	case Admin:
 		subject = pkix.Name{CommonName: AdminCN, Organization: []string{Organization}}
 		c.authInfo = GenerateAuthInfoAdminName(c.CpName)
-		c.secretName = AdminConfSecret
+		c.secretName = util.AdminConfSecret
 	case ControllerManager:
 		subject = pkix.Name{CommonName: ContrCMCN}
 		c.authInfo = ContrCMCN

--- a/pkg/reconcilers/k8s/reconciler.go
+++ b/pkg/reconcilers/k8s/reconciler.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s
+
+import (
+	"context"
+
+	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"github.com/kubestellar/kubeflex/pkg/certs"
+)
+
+// K8sReconciler reconciles a k8s ControlPlane
+type K8sReconciler struct {
+	*shared.BaseReconciler
+}
+
+func New(cl client.Client, scheme *runtime.Scheme) *K8sReconciler {
+	return &K8sReconciler{
+		BaseReconciler: &shared.BaseReconciler{
+			Client: cl,
+			Scheme: scheme,
+		},
+	}
+}
+
+func (r *K8sReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
+	_ = clog.FromContext(ctx)
+
+	if err := r.BaseReconciler.ReconcileNamespace(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	crts, err := r.ReconcileCertsSecret(ctx, hcp)
+	if err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	// reconcile kubeconfig for admin
+	confGen := certs.ConfigGen{CpName: hcp.Name, CpHost: hcp.Name, CpPort: shared.SecurePort}
+	confGen.Target = certs.Admin
+	if err = r.ReconcileKubeconfigSecret(ctx, crts, confGen, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	// reconcile kubeconfig for cm
+	confGen.Target = certs.ControllerManager
+	confGen.CpHost = hcp.Name
+	if err = r.ReconcileKubeconfigSecret(ctx, crts, confGen, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err = r.ReconcileAPIServerDeployment(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err = r.ReconcileAPIServerService(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err = r.ReconcileAPIServerIngress(ctx, hcp, ""); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err = r.ReconcileCMDeployment(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	return r.UpdateStatusForSyncingSuccess(ctx, hcp)
+}

--- a/pkg/reconcilers/k8s/secret.go
+++ b/pkg/reconcilers/k8s/secret.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package k8s
 
 import (
 	"context"
@@ -31,7 +31,7 @@ import (
 	"github.com/kubestellar/kubeflex/pkg/util"
 )
 
-func (r *ControlPlaneReconciler) ReconcileCertsSecret(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (*certs.Certs, error) {
+func (r *K8sReconciler) ReconcileCertsSecret(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (*certs.Certs, error) {
 	_ = clog.FromContext(ctx)
 	namespace := util.GenerateNamespaceFromControlPlaneName(hcp.Name)
 
@@ -63,7 +63,7 @@ func (r *ControlPlaneReconciler) ReconcileCertsSecret(ctx context.Context, hcp *
 	return nil, nil
 }
 
-func (r *ControlPlaneReconciler) ReconcileKubeconfigSecret(ctx context.Context, crts *certs.Certs, conf certs.ConfigGen, hcp *tenancyv1alpha1.ControlPlane) error {
+func (r *K8sReconciler) ReconcileKubeconfigSecret(ctx context.Context, crts *certs.Certs, conf certs.ConfigGen, hcp *tenancyv1alpha1.ControlPlane) error {
 	// TODO - temp hack - we should make this independent of the certs gen.
 	// Should gen kconfig from certs secret otherwise it may fail if certs are not generated before this func
 	if crts == nil {

--- a/pkg/reconcilers/ocm/chart.go
+++ b/pkg/reconcilers/ocm/chart.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"github.com/kubestellar/kubeflex/pkg/helm"
+	"github.com/kubestellar/kubeflex/pkg/util"
+)
+
+// helm install -n cp3-system multicluster-controlplane \
+//    oci://quay.io/pdettori/multicluster-controlplane-chart \
+//   --version 0.1.0 \
+//   --create-namespace \
+//   --set image=quay.io/pdettori/multicluster-controlplane:latest \
+//   --set route.enabled=false \
+//   --set apiserver.externalHostname=cp3.localtest.me \
+//   --set apiserver.internalHostname=kubeflex-control-plane \
+//   --set apiserver.port=9443 \
+//   --set nodeport.enabled=true \
+//   --set nodeport.port=30443
+
+const (
+	URL         = "oci://quay.io/pdettori/multicluster-controlplane-chart:0.1.0"
+	RepoName    = "multicluster-controlplane"
+	ChartName   = "multicluster-controlplane-chart"
+	ReleaseName = "multicluster-controlplane"
+)
+
+var (
+	configs = []string{
+		"image=quay.io/pdettori/multicluster-controlplane:latest",
+		"route.enabled=false",
+		"apiserver.internalHostname=kubeflex-control-plane",
+		"apiserver.port=9443",
+		"nodeport.enabled=false",
+	}
+
+	Args = map[string]string{
+		"set": "image=quay.io/pdettori/multicluster-controlplane:latest,route.enabled=false",
+	}
+)
+
+func (r *OCMReconciler) ReconcileChart(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
+	configs = append(configs, fmt.Sprintf("apiserver.externalHostname=%s", util.GenerateDevLocalDNSName(hcp.Name)))
+	h := &helm.HelmHandler{
+		URL:         URL,
+		RepoName:    RepoName,
+		ChartName:   ChartName,
+		Namespace:   util.GenerateNamespaceFromControlPlaneName(hcp.Name),
+		ReleaseName: ReleaseName,
+		Args:        map[string]string{"set": strings.Join(configs, ",")},
+	}
+	err := helm.Init(ctx, h)
+	if err != nil {
+		return err
+	}
+
+	if !h.IsDeployed() {
+		err := h.Install()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/reconcilers/ocm/rbac.go
+++ b/pkg/reconcilers/ocm/rbac.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocm
+
+import (
+	"context"
+
+	"github.com/kubestellar/kubeflex/pkg/util"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	clog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+)
+
+const (
+	roleName = "cluster-info-updater"
+)
+
+func (r *OCMReconciler) ReconcileUpdateClusterInfoJobRole(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
+	_ = clog.FromContext(ctx)
+	namespace := util.GenerateNamespaceFromControlPlaneName(hcp.Name)
+
+	// create role object
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: namespace,
+		},
+	}
+
+	err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(role), role, &client.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			role := generateClusterInfoJobRole(roleName, namespace)
+			if err := controllerutil.SetControllerReference(hcp, role, r.Scheme); err != nil {
+				return nil
+			}
+			err = r.Client.Create(context.TODO(), role, &client.CreateOptions{})
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func generateClusterInfoJobRole(name, namespace string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+				Verbs:     []string{"watch", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"secrets"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+}
+
+func (r *OCMReconciler) ReconcileUpdateClusterInfoJobRoleBinding(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
+	_ = clog.FromContext(ctx)
+	namespace := util.GenerateNamespaceFromControlPlaneName(hcp.Name)
+
+	// create role binding object
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: namespace,
+		},
+	}
+
+	err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(binding), binding, &client.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			binding := generateClusterInfoJobRoleBinding(roleName, namespace)
+			if err := controllerutil.SetControllerReference(hcp, binding, r.Scheme); err != nil {
+				return nil
+			}
+			err = r.Client.Create(context.TODO(), binding, &client.CreateOptions{})
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func generateClusterInfoJobRoleBinding(name, namespace string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "default",
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/reconcilers/ocm/reconciler.go
+++ b/pkg/reconcilers/ocm/reconciler.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocm
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
+)
+
+// OCMReconciler reconciles a OCM ControlPlane
+type OCMReconciler struct {
+	*shared.BaseReconciler
+}
+
+func New(cl client.Client, scheme *runtime.Scheme) *OCMReconciler {
+	return &OCMReconciler{
+		BaseReconciler: &shared.BaseReconciler{
+			Client: cl,
+			Scheme: scheme,
+		},
+	}
+}
+
+func (r *OCMReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
+	_ = clog.FromContext(ctx)
+
+	if err := r.BaseReconciler.ReconcileNamespace(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err := r.ReconcileChart(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err := r.ReconcileOCMService(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err := r.ReconcileAPIServerIngress(ctx, hcp, ServiceName); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err := r.ReconcileUpdateClusterInfoJobRole(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err := r.ReconcileUpdateClusterInfoJobRoleBinding(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	if err := r.ReconcileUpdateClusterInfoJob(ctx, hcp); err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
+	return r.UpdateStatusForSyncingSuccess(ctx, hcp)
+}

--- a/pkg/reconcilers/ocm/service.go
+++ b/pkg/reconcilers/ocm/service.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ocm
+
+import (
+	"context"
+
+	"github.com/kubestellar/kubeflex/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	clog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
+)
+
+const (
+	ServiceName = "multicluster-controlplane"
+)
+
+func (r *OCMReconciler) ReconcileOCMService(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
+	_ = clog.FromContext(ctx)
+	namespace := util.GenerateNamespaceFromControlPlaneName(hcp.Name)
+
+	// create service object
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceName,
+			Namespace: namespace,
+		},
+	}
+
+	err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(service), service, &client.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			service := generateAPIServerService(ServiceName, namespace)
+			if err := controllerutil.SetControllerReference(hcp, service, r.Scheme); err != nil {
+				return nil
+			}
+			err = r.Client.Create(context.TODO(), service, &client.CreateOptions{})
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func generateAPIServerService(name, namespace string) *corev1.Service {
+	ds := corev1.IPFamilyPolicyPreferDualStack
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "multicluster-controlplane",
+			},
+			Type: corev1.ServiceTypeNodePort,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       shared.SecurePort,
+					Name:       "https",
+					Protocol:   "TCP",
+					TargetPort: intstr.FromInt(shared.TargetPort),
+				},
+			},
+			IPFamilyPolicy: &ds,
+			IPFamilies: []corev1.IPFamily{
+				corev1.IPv4Protocol,
+				corev1.IPv6Protocol,
+			},
+		},
+	}
+}

--- a/pkg/reconcilers/shared/config.go
+++ b/pkg/reconcilers/shared/config.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+const (
+	SecurePort    = 9444
+	TargetPort    = 9443
+	CMHealthzPort = 10257
+)

--- a/pkg/reconcilers/shared/namespace.go
+++ b/pkg/reconcilers/shared/namespace.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"context"
+
+	"github.com/kubestellar/kubeflex/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	clog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+)
+
+func (r *BaseReconciler) ReconcileNamespace(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
+	_ = clog.FromContext(ctx)
+	namespace := util.GenerateNamespaceFromControlPlaneName(hcp.Name)
+
+	// create namespace object
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+
+	err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(ns), ns, &client.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			if err := controllerutil.SetControllerReference(hcp, ns, r.Scheme); err != nil {
+				return err
+			}
+			if err = r.Client.Create(context.TODO(), ns, &client.CreateOptions{}); err != nil {
+				return err
+			}
+		}
+		return err
+	}
+	return nil
+}

--- a/pkg/reconcilers/shared/reconciler.go
+++ b/pkg/reconcilers/shared/reconciler.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// BaseReconciler provide common reconcilers used by other reconcilers
+type BaseReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+func (r *BaseReconciler) UpdateStatusForSyncingError(hcp *tenancyv1alpha1.ControlPlane, e error) (ctrl.Result, error) {
+	tenancyv1alpha1.EnsureCondition(hcp, tenancyv1alpha1.ConditionReconcileError(e))
+	err := r.Status().Update(context.Background(), hcp)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(e, err.Error())
+	}
+	return ctrl.Result{}, err
+}
+
+func (r *BaseReconciler) UpdateStatusForSyncingSuccess(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
+	_ = clog.FromContext(ctx)
+	tenancyv1alpha1.EnsureCondition(hcp, tenancyv1alpha1.ConditionReconcileSuccess())
+	err := r.Status().Update(context.Background(), hcp)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, err
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,16 +20,20 @@ import (
 	"fmt"
 	"strings"
 
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/pkg/client"
 )
 
 const (
 	APIServerDeploymentName = "kube-apiserver"
+	OCMServerDeploymentName = "multicluster-controlplane"
 	CMDeploymentName        = "kube-controller-manager"
 	ProjectName             = "kubeflex"
 	DBReleaseName           = "postgres"
 	SystemNamespace         = "kubeflex-system"
 	IngressSecurePort       = "9443"
+	AdminConfSecret         = "admin-kubeconfig"
+	OCMKubeConfigSecret     = "multicluster-controlplane-kubeconfig"
 )
 
 func GenerateNamespaceFromControlPlaneName(name string) string {
@@ -68,4 +72,28 @@ func GetKubernetesClusterVersionInfo(kubeconfig string) (string, error) {
 		return "", err
 	}
 	return serverVersion.String(), nil
+}
+
+func GetKubeconfSecretNameByControlPlaneType(controlPlaneType string) string {
+	switch controlPlaneType {
+	case string(tenancyv1alpha1.ControlPlaneTypeK8S):
+		return AdminConfSecret
+	case string(tenancyv1alpha1.ControlPlaneTypeOCM):
+		return OCMKubeConfigSecret
+	default:
+		// TODO - should we instead throw an error?
+		return AdminConfSecret
+	}
+}
+
+func GetAPIServerDeploymentNameByControlPlaneType(controlPlaneType string) string {
+	switch controlPlaneType {
+	case string(tenancyv1alpha1.ControlPlaneTypeK8S):
+		return APIServerDeploymentName
+	case string(tenancyv1alpha1.ControlPlaneTypeOCM):
+		return OCMServerDeploymentName
+	default:
+		// TODO - should we instead throw an error?
+		return APIServerDeploymentName
+	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Adds support for open cluster management control plane. A control plane type can be added just specifying a type "com" in the control plane CR.

## Related issue(s)

Fixes #56 
