### PR TITLE
🐛 Improve apiserver service name for controller manager

### DIFF
--- a/pkg/reconcilers/k8s/deployment.go
+++ b/pkg/reconcilers/k8s/deployment.go
@@ -291,7 +291,7 @@ func (r *K8sReconciler) generateCMDeployment(cpName, namespace string) (*appsv1.
 							ImagePullPolicy: v1.PullIfNotPresent,
 							Command: []string{
 								"kube-controller-manager",
-								fmt.Sprintf("--master=https://%s:%d", cpName, shared.SecurePort),
+								fmt.Sprintf("--master=https://%s:%d", cpName+"."+cpName+"-system", shared.SecurePort),
 								"--authentication-kubeconfig=/etc/kubernetes/kubeconfig",
 								"--authorization-kubeconfig=/etc/kubernetes/kubeconfig",
 								"--bind-address=0.0.0.0",


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR uses an improved address in the `--master` flag for the `kube-controller-manager` inside a controller plane of type `k8s`.

Before the change, the controller manager failed to verify x509 certificate.
```
E0726 15:41:22.225385       1 leaderelection.go:327] error retrieving resource lock kube-system/kube-controller-manager: Get "https://consumer0:9444/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager?timeout=5s": tls: failed to verify certificate: x509: certificate is valid for kubernetes, kubernetes.default, kubernetes.default.svc, kubernetes.default.svc.cluster, kubernetes.default.svc.cluster.local, localhost, kubeflex-control-plane, consumer0.consumer0-system, consumer0.consumer0-system.svc, consumer0.consumer0-system.svc.cluster, consumer0.consumer0-system.svc.cluster.local, consumer0.localtest.me, not consumer0
```

After editing the live manifest of the controller manager, the error goes away, e.g.:
```
         - --master=https://provider.provider-system:9444
```

## Related issue(s)
https://github.com/kubestellar/kubestellar/issues/656

