### PR TITLE
✨ use ConfigMap to store KubeFlex configuration such as external port for ingress and domain

### DIFF
--- a/chart/templates/operator.yaml
+++ b/chart/templates/operator.yaml
@@ -11,10 +11,26 @@ spec:
     kind: ControlPlane
     listKind: ControlPlaneList
     plural: controlplanes
+    shortNames:
+    - cp
+    - cps
     singular: controlplane
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNCED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .spec.type
+      name: TYPE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ControlPlane is the Schema for the controlplanes API
@@ -35,10 +51,54 @@ spec:
             description: ControlPlaneSpec defines the desired state of ControlPlane
             properties:
               backend:
+                enum:
+                - shared
+                - dedicated
+                type: string
+              type:
+                enum:
+                - k8s
+                - ocm
+                - vcluster
                 type: string
             type: object
           status:
             description: ControlPlaneStatus defines the observed state of ControlPlane
+            properties:
+              conditions:
+                items:
+                  description: ControlPlaneCondition describes the state of a control
+                    plane at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+            required:
+            - conditions
+            - observedGeneration
             type: object
         type: object
     served: true
@@ -125,7 +185,103 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
   verbs:
   - create
   - delete
@@ -185,7 +341,27 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
   verbs:
   - create
   - delete
@@ -198,6 +374,54 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
   verbs:
   - create
   - delete
@@ -337,6 +561,15 @@ subjects:
   namespace: kubeflex-system
 ---
 apiVersion: v1
+data:
+  domain: '{{ .Values.domain }}'
+  externalPort: '{{ .Values.externalPort }}'
+kind: ConfigMap
+metadata:
+  name: kubeflex-config
+  namespace: kubeflex-system
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -427,7 +660,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-        image: ghcr.io/kubestellar/kubeflex/manager:0.1.0
+        image: ghcr.io/kubestellar/kubeflex/manager:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,4 +2,5 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
+domain: localtest.me
+externalPort: "9443"

--- a/cmd/kflex/init/config.go
+++ b/cmd/kflex/init/config.go
@@ -32,7 +32,7 @@ var (
 	PostgresArgs = map[string]string{
 		"set": "primary.extendedConfiguration=max_connections=1000,primary.priorityClassName=system-node-critical",
 	}
-	KflexOperatorArgs = map[string]string{
-		"version": "v0.1.0",
+	OperatorConfigs = []string{
+		"version=v0.1.0",
 	}
 )

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -42,6 +42,8 @@ var Version string
 var BuildDate string
 var CType string
 var BkType string
+var domain string
+var externalPort int
 
 // defaults
 const BKTypeDefault = string(tenancyv1alpha1.BackendDBTypeShared)
@@ -79,7 +81,7 @@ var initCmd = &cobra.Command{
 		if createkind {
 			cluster.CreateKindCluster()
 		}
-		in.Init(ctx, kubeconfig, Version, BuildDate)
+		in.Init(ctx, kubeconfig, Version, BuildDate, domain, fmt.Sprint(externalPort))
 	},
 }
 
@@ -155,6 +157,8 @@ func init() {
 	initCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to kubeconfig file")
 	initCmd.Flags().IntVarP(&verbosity, "verbosity", "v", 0, "log level") // TODO - figure out how to inject verbosity
 	initCmd.Flags().BoolVarP(&createkind, "create-kind", "c", false, "Create and configure a kind cluster for installing Kubeflex")
+	initCmd.Flags().StringVarP(&domain, "domain", "d", "localtest.me", "domain for FQDN")
+	initCmd.Flags().IntVarP(&externalPort, "externalPort", "p", 9443, "external port used by ingress")
 
 	createCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to kubeconfig file")
 	createCmd.Flags().IntVarP(&verbosity, "verbosity", "v", 0, "log level") // TODO - figure out how to inject verbosity

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,9 @@
 resources:
 - manager.yaml
+- config.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: ko.local/manager
-  newTag: e3e4723
+  newName: ghcr.io/kubestellar/kubeflex/manager
+  newTag: latest

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -15,6 +15,12 @@ psql -h mypsql-postgresql.kubeflex-system.svc -U postgres
 openssl x509 -noout -text -in certs/apiserver.crt 
 ```
 
+### Manually creating the configmap with KubeFlex defaults
+
+```shell
+create configmap kubeflex-config -n kubeflex-system --from-literal=externalPort=9443 --from-literal=domain=localtest.me
+```
+
 ### Get decoded value from secret
 
 ```shell

--- a/pkg/certs/kconfig_gen.go
+++ b/pkg/certs/kconfig_gen.go
@@ -50,6 +50,7 @@ type ConfigGen struct {
 	CpName      string
 	CpNamespace string
 	CpHost      string
+	CpDomain    string
 	CpPort      int
 	Target      ConfigTarget
 	caKey       *rsa.PrivateKey
@@ -152,7 +153,7 @@ func (c *ConfigGen) generateConfig() *clientcmdapi.Config {
 }
 
 func (c *ConfigGen) generateServerEndpoint() string {
-	return fmt.Sprintf("https://%s:%s", util.GenerateDevLocalDNSName(c.CpName), util.IngressSecurePort)
+	return fmt.Sprintf("https://%s:%d", util.GenerateDevLocalDNSName(c.CpName, c.CpDomain), c.CpPort)
 }
 
 func GenerateClusterName(cpName string) string {

--- a/pkg/reconcilers/ocm/chart.go
+++ b/pkg/reconcilers/ocm/chart.go
@@ -23,6 +23,7 @@ import (
 
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/pkg/helm"
+	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
 	"github.com/kubestellar/kubeflex/pkg/util"
 )
 
@@ -43,8 +44,8 @@ var (
 	}
 )
 
-func (r *OCMReconciler) ReconcileChart(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
-	configs = append(configs, fmt.Sprintf("apiserver.externalHostname=%s", util.GenerateDevLocalDNSName(hcp.Name)))
+func (r *OCMReconciler) ReconcileChart(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane, cfg *shared.SharedConfig) error {
+	configs = append(configs, fmt.Sprintf("apiserver.externalHostname=%s", util.GenerateDevLocalDNSName(hcp.Name, cfg.Domain)))
 	h := &helm.HelmHandler{
 		URL:         URL,
 		RepoName:    RepoName,

--- a/pkg/reconcilers/ocm/reconciler.go
+++ b/pkg/reconcilers/ocm/reconciler.go
@@ -49,11 +49,16 @@ func New(cl client.Client, scheme *runtime.Scheme) *OCMReconciler {
 func (r *OCMReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
 	_ = clog.FromContext(ctx)
 
+	cfg, err := r.BaseReconciler.GetConfig(ctx)
+	if err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
 	if err := r.BaseReconciler.ReconcileNamespace(ctx, hcp); err != nil {
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 
-	if err := r.ReconcileChart(ctx, hcp); err != nil {
+	if err := r.ReconcileChart(ctx, hcp, cfg); err != nil {
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 
@@ -61,7 +66,7 @@ func (r *OCMReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.Cont
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 
-	if err := r.ReconcileAPIServerIngress(ctx, hcp, ServiceName, shared.SecurePort); err != nil {
+	if err := r.ReconcileAPIServerIngress(ctx, hcp, ServiceName, shared.SecurePort, cfg.Domain); err != nil {
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 

--- a/pkg/reconcilers/ocm/service.go
+++ b/pkg/reconcilers/ocm/service.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	ServiceName = "multicluster-controlplane"
+	TargetPort  = 9443
 )
 
 func (r *OCMReconciler) ReconcileOCMService(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
@@ -82,7 +83,7 @@ func generateAPIServerService(name, namespace string) *corev1.Service {
 					Port:       shared.SecurePort,
 					Name:       "https",
 					Protocol:   "TCP",
-					TargetPort: intstr.FromInt(shared.TargetPort),
+					TargetPort: intstr.FromInt(TargetPort),
 				},
 			},
 			IPFamilyPolicy: &ds,

--- a/pkg/reconcilers/shared/config.go
+++ b/pkg/reconcilers/shared/config.go
@@ -18,6 +18,5 @@ package shared
 
 const (
 	SecurePort    = 9444
-	TargetPort    = 9443
 	CMHealthzPort = 10257
 )

--- a/pkg/reconcilers/shared/ingress.go
+++ b/pkg/reconcilers/shared/ingress.go
@@ -39,7 +39,7 @@ var (
 	pathTypePrefix = networkingv1.PathTypePrefix
 )
 
-func (r *BaseReconciler) ReconcileAPIServerIngress(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane, svcName string, svcPort int) error {
+func (r *BaseReconciler) ReconcileAPIServerIngress(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane, svcName string, svcPort int, domain string) error {
 	_ = clog.FromContext(ctx)
 	namespace := util.GenerateNamespaceFromControlPlaneName(hcp.Name)
 
@@ -58,7 +58,7 @@ func (r *BaseReconciler) ReconcileAPIServerIngress(ctx context.Context, hcp *ten
 	err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(ingress), ingress, &client.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			ingress = generateAPIServerIngress(hcp.Name, svcName, namespace, svcPort)
+			ingress = generateAPIServerIngress(hcp.Name, svcName, namespace, svcPort, domain)
 			if err := controllerutil.SetControllerReference(hcp, ingress, r.Scheme); err != nil {
 				return nil
 			}
@@ -71,7 +71,7 @@ func (r *BaseReconciler) ReconcileAPIServerIngress(ctx context.Context, hcp *ten
 	return nil
 }
 
-func generateAPIServerIngress(name, svcName, namespace string, svcPort int) *networkingv1.Ingress {
+func generateAPIServerIngress(name, svcName, namespace string, svcPort int, domain string) *networkingv1.Ingress {
 	return &networkingv1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
@@ -88,7 +88,7 @@ func generateAPIServerIngress(name, svcName, namespace string, svcPort int) *net
 			IngressClassName: pointer.String(IngressClassNameNGINX),
 			Rules: []networkingv1.IngressRule{
 				{
-					Host: util.GenerateDevLocalDNSName(name),
+					Host: util.GenerateDevLocalDNSName(name, domain),
 					IngressRuleValue: networkingv1.IngressRuleValue{
 						HTTP: &networkingv1.HTTPIngressRuleValue{
 							Paths: []networkingv1.HTTPIngressPath{

--- a/pkg/reconcilers/vcluster/chart.go
+++ b/pkg/reconcilers/vcluster/chart.go
@@ -25,6 +25,7 @@ import (
 
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/pkg/helm"
+	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
 	"github.com/kubestellar/kubeflex/pkg/util"
 )
 
@@ -41,11 +42,11 @@ var (
 	}
 )
 
-func (r *VClusterReconciler) ReconcileChart(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
+func (r *VClusterReconciler) ReconcileChart(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane, cfg *shared.SharedConfig) error {
 	_ = clog.FromContext(ctx)
-	localDNSName := util.GenerateDevLocalDNSName(hcp.Name)
+	localDNSName := util.GenerateDevLocalDNSName(hcp.Name, cfg.Domain)
 	configs = append(configs, fmt.Sprintf("syncer.extraArgs[0]=--tls-san=%s", localDNSName))
-	configs = append(configs, fmt.Sprintf("syncer.extraArgs[1]=--out-kube-config-server=https://%s:9443", localDNSName))
+	configs = append(configs, fmt.Sprintf("syncer.extraArgs[1]=--out-kube-config-server=https://%s:%d", localDNSName, cfg.ExternalPort))
 	h := &helm.HelmHandler{
 		URL:         URL,
 		RepoName:    RepoName,

--- a/pkg/reconcilers/vcluster/reconciler.go
+++ b/pkg/reconcilers/vcluster/reconciler.go
@@ -54,15 +54,20 @@ func New(cl client.Client, scheme *runtime.Scheme) *VClusterReconciler {
 func (r *VClusterReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
 	_ = clog.FromContext(ctx)
 
+	cfg, err := r.BaseReconciler.GetConfig(ctx)
+	if err != nil {
+		return r.UpdateStatusForSyncingError(hcp, err)
+	}
+
 	if err := r.BaseReconciler.ReconcileNamespace(ctx, hcp); err != nil {
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 
-	if err := r.ReconcileChart(ctx, hcp); err != nil {
+	if err := r.ReconcileChart(ctx, hcp, cfg); err != nil {
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 
-	if err := r.ReconcileAPIServerIngress(ctx, hcp, ServiceName, ServicePort); err != nil {
+	if err := r.ReconcileAPIServerIngress(ctx, hcp, ServiceName, ServicePort, cfg.Domain); err != nil {
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,7 +32,7 @@ const (
 	ProjectName                  = "kubeflex"
 	DBReleaseName                = "postgres"
 	SystemNamespace              = "kubeflex-system"
-	IngressSecurePort            = "9443"
+	SystemConfigMap              = "kubeflex-config"
 	AdminConfSecret              = "admin-kubeconfig"
 	OCMKubeConfigSecret          = "multicluster-controlplane-kubeconfig"
 	VClusterKubeConfigSecret     = "vc-vcluster"
@@ -46,10 +46,8 @@ func GenerateNamespaceFromControlPlaneName(name string) string {
 
 // GenerateDevLocalDNSName: generates the local dns name for test/dev
 // from the controlplane name
-func GenerateDevLocalDNSName(name string) string {
-	// At this time we use localtest.me for resolving to localhost.
-	// TODO: make this configurable so that user can pick his preferred provider.
-	return fmt.Sprintf("%s.localtest.me", name)
+func GenerateDevLocalDNSName(name, domain string) string {
+	return fmt.Sprintf("%s.%s", name, domain)
 }
 
 func GenerateHostedDNSName(namespace, name string) []string {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Allow to use config map to set configuration, for example allow to use existing cluster with different port mapping for ingress than default port 9443 and use a domain different than "localtest.me" 

## Related issue(s)

Fixes #83 
