### PR TITLE
🐛 allows incluster access with cm-kubeconfig and admin-kubeconfig

### DIFF
--- a/pkg/reconcilers/k8s/reconciler.go
+++ b/pkg/reconcilers/k8s/reconciler.go
@@ -60,8 +60,8 @@ func (r *K8sReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.Cont
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 
+	confGen := &certs.ConfigGen{CpName: hcp.Name, CpHost: hcp.Name, CpPort: cfg.ExternalPort, CpDomain: cfg.Domain}
 	// reconcile kubeconfig for admin
-	confGen := certs.ConfigGen{CpName: hcp.Name, CpHost: hcp.Name, CpPort: cfg.ExternalPort, CpDomain: cfg.Domain}
 	confGen.Target = certs.Admin
 	if err = r.ReconcileKubeconfigSecret(ctx, crts, confGen, hcp); err != nil {
 		return r.UpdateStatusForSyncingError(hcp, err)

--- a/pkg/reconcilers/k8s/secret.go
+++ b/pkg/reconcilers/k8s/secret.go
@@ -64,7 +64,7 @@ func (r *K8sReconciler) ReconcileCertsSecret(ctx context.Context, hcp *tenancyv1
 	return nil, nil
 }
 
-func (r *K8sReconciler) ReconcileKubeconfigSecret(ctx context.Context, crts *certs.Certs, conf certs.ConfigGen, hcp *tenancyv1alpha1.ControlPlane) error {
+func (r *K8sReconciler) ReconcileKubeconfigSecret(ctx context.Context, crts *certs.Certs, conf *certs.ConfigGen, hcp *tenancyv1alpha1.ControlPlane) error {
 	// TODO - temp hack - we should make this independent of the certs gen.
 	// Should gen kconfig from certs secret otherwise it may fail if certs are not generated before this func
 	if crts == nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -37,6 +37,7 @@ const (
 	OCMKubeConfigSecret          = "multicluster-controlplane-kubeconfig"
 	VClusterKubeConfigSecret     = "vc-vcluster"
 	KubeconfigSecretKeyDefault   = "kubeconfig"
+	KubeconfigSecretKeyInCluster = "kubeconfig-incluster"
 	KubeconfigSecretKeyVCluster  = "config"
 )
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fixes cm-kubeconfig to point to correct DNS name for in-cluster access. It also adds a new kubeconfig with admin authority to `admin-kubeconfig` secret, with key `kubeconfig-incluster`

## Related issue(s)

Fixes #89 
