### PR TITLE
✨ load cp kubeconfig context from server if not in local kubeconfig

### DIFF
--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -17,15 +17,21 @@ limitations under the License.
 package ctx
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
 	"time"
 
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
 	"github.com/kubestellar/kubeflex/pkg/certs"
+	kfclient "github.com/kubestellar/kubeflex/pkg/client"
 	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
 	"github.com/kubestellar/kubeflex/pkg/util"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type CPCtx struct {
@@ -59,8 +65,19 @@ func (c *CPCtx) Context() {
 		ctxName := certs.GenerateContextName(c.Name)
 		util.PrintStatus(fmt.Sprintf("Switching to context %s...", ctxName), done, &wg)
 		if err = kubeconfig.SwitchContext(kconf, c.Name); err != nil {
-			fmt.Fprintf(os.Stderr, "Error switching kubeconfig context: %s\n", err)
-			os.Exit(1)
+			fmt.Fprintf(os.Stderr, "kubeconfig context %s not found, trying to load from server...\n", err)
+			if err := c.switchToInitialContextAndWrite(kconf); err != nil {
+				fmt.Fprintf(os.Stderr, "Error switching back to initial context: %s\n", err)
+				os.Exit(1)
+			}
+			if err = c.loadAndMergeFromServer(kconf); err != nil {
+				fmt.Fprintf(os.Stderr, "Error loading kubeconfig context from server: %s\n", err)
+				os.Exit(1)
+			}
+			if err = kubeconfig.SwitchContext(kconf, c.Name); err != nil {
+				fmt.Fprintf(os.Stderr, "Error switching kubeconfig context after loading from server: %s\n", err)
+				os.Exit(1)
+			}
 		}
 		done <- true
 	}
@@ -70,4 +87,35 @@ func (c *CPCtx) Context() {
 		os.Exit(1)
 	}
 	wg.Wait()
+}
+
+func (c *CPCtx) loadAndMergeFromServer(kconfig *api.Config) error {
+	kfcClient := *(kfclient.GetClient(c.Kubeconfig))
+	cp := &tenancyv1alpha1.ControlPlane{
+		ObjectMeta: v1.ObjectMeta{
+			Name: c.CP.Name,
+		},
+	}
+	if err := kfcClient.Get(context.TODO(), client.ObjectKeyFromObject(cp), cp, &client.GetOptions{}); err != nil {
+		return fmt.Errorf("control plane not found on server: %s", err)
+	}
+
+	clientset := *(kfclient.GetClientSet(c.Kubeconfig))
+	if err := kubeconfig.LoadAndMergeNoWrite(c.Ctx, clientset, c.Name, string(cp.Spec.Type), kconfig); err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading and merging kubeconfig: %v\n", err)
+		os.Exit(1)
+	}
+	return nil
+}
+
+func (c *CPCtx) switchToInitialContextAndWrite(kconf *api.Config) error {
+	if kubeconfig.IsInitialConfigSet(kconf) {
+		if err := kubeconfig.SwitchToInitialContext(kconf, false); err != nil {
+			return err
+		}
+		if err := kubeconfig.WriteKubeconfig(c.Ctx, kconf); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -52,6 +52,22 @@ func LoadAndMerge(ctx context.Context, client kubernetes.Clientset, name, contro
 	return WriteKubeconfig(ctx, konfig)
 }
 
+// LoadAndMergeNoWrite: works as LoadAndMerge but on supplied konfig from file and does not write it back
+func LoadAndMergeNoWrite(ctx context.Context, client kubernetes.Clientset, name, controlPlaneType string, konfig *clientcmdapi.Config) error {
+	cpKonfig, err := loadControlPlaneKubeconfig(ctx, client, name, controlPlaneType)
+	if err != nil {
+		return err
+	}
+	adjustConfigKeys(cpKonfig, name, controlPlaneType)
+
+	err = merge(konfig, cpKonfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func loadControlPlaneKubeconfig(ctx context.Context, client kubernetes.Clientset, name, controlPlaneType string) (*clientcmdapi.Config, error) {
 	namespace := util.GenerateNamespaceFromControlPlaneName(name)
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
load cp kubeconfig context from server if not in local kubeconfig

## Related issue(s)

Fixes #94 
