### PR TITLE
🐛 pin vcluster version to 0.16.4

### DIFF
--- a/pkg/helm/installer.go
+++ b/pkg/helm/installer.go
@@ -52,9 +52,11 @@ type HelmHandler struct {
 	ChartName   string
 	ReleaseName string
 	Namespace   string
-	Args        map[string]string
-	log         logr.Logger
-	settings    *cli.EnvSettings
+	// version is only used for "classic" helm charts, not OCI
+	Version  string
+	Args     map[string]string
+	log      logr.Logger
+	settings *cli.EnvSettings
 }
 
 func Init(ctx context.Context, handler *HelmHandler) error {
@@ -194,6 +196,11 @@ func (h *HelmHandler) chartInstall() error {
 
 	if client.Version == "" && client.Devel {
 		client.Version = ">0.0.0-0"
+	}
+
+	// set the version if specified, otherwise default to latest version
+	if h.Version != "" {
+		client.ChartPathOptions.Version = h.Version
 	}
 
 	client.ReleaseName = h.ReleaseName

--- a/pkg/reconcilers/vcluster/chart.go
+++ b/pkg/reconcilers/vcluster/chart.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	URL                = "https://charts.loft.sh"
+	Version            = "0.16.4"
 	RepoName           = "loft"
 	ChartName          = "vcluster"
 	ReleaseName        = "vcluster"
@@ -69,6 +70,7 @@ func (r *VClusterReconciler) ReconcileChart(ctx context.Context, hcp *tenancyv1a
 		URL:         URL,
 		RepoName:    RepoName,
 		ChartName:   ChartName,
+		Version:     Version,
 		Namespace:   util.GenerateNamespaceFromControlPlaneName(hcp.Name),
 		ReleaseName: ReleaseName,
 		Args:        map[string]string{"set": strings.Join(configs, ",")},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
pin vcluster version to 0.16.4. We found that 0.17.0 and 0.17.1 (latest) do not work on kind v0.19.0 and Kubernetes 1.27.1

## Related issue(s)

Fixes #121 
