### PR TITLE
🌱 Use a multi-platform image for the kubeflex-operator job

### DIFF
--- a/chart/templates/install-hooks.yaml
+++ b/chart/templates/install-hooks.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: "{{ .Release.Name }}"
-        image: public.ecr.aws/bitnami/kubectl:1.27.8-debian-11-r0
+        image: bitnami/kubectl:1.27.8
         command:
         - sh
         - -c


### PR DESCRIPTION
## Summary
I tried to run kubeflex 0.4.0 on an AWS VM which has the 'Graviton' processor, and got an `exec format error` within the `kubeflex-operator` job. Detailed as follows.

### Environment
```
ubuntu@ip-172-31-38-158:~/kubestellar$ kflex version
Kubeflex version: v0.4.0.ff7cd13 2024-01-17T03:26:14Z
Kubernetes version: v1.27.3
ubuntu@ip-172-31-38-158:~/kubestellar$ uname -a
Linux ip-172-31-38-158 6.2.0-1012-aws #12~22.04.1-Ubuntu SMP Thu Sep  7 16:00:15 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux
```

### Terminal Dump
After `kflex init -c`, I checked the `kubeflex-operator` job:
```
ubuntu@ip-172-31-38-158:~/kubestellar$ kc -n kubeflex-system get deploy,sts,job,po
NAME                                          READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/kubeflex-controller-manager   1/1     1            1           2m43s

NAME                                   READY   AGE
statefulset.apps/postgres-postgresql   1/1     3m23s

NAME                          COMPLETIONS   DURATION   AGE
job.batch/kubeflex-operator   0/1           2m43s      2m43s

NAME                                             READY   STATUS    RESTARTS   AGE
pod/kubeflex-controller-manager-f6dfb645-fbr76   2/2     Running   0          2m43s
pod/kubeflex-operator-n8drg                      0/1     Error     0          84s
pod/kubeflex-operator-q6wqf                      0/1     Error     0          2m43s
pod/kubeflex-operator-rf2ng                      0/1     Error     0          2m28s
pod/kubeflex-operator-rjb4x                      0/1     Error     0          2m6s
pod/kubeflex-operator-rmcxh                      0/1     Error     0          3s
pod/postgres-postgresql-0                        1/1     Running   0          3m13s
ubuntu@ip-172-31-38-158:~/kubestellar$ kc -n kubeflex-system get job kubeflex-operator -oyaml | yq .status
conditions:
  - lastProbeTime: "2024-01-19T21:30:31Z"
    lastTransitionTime: "2024-01-19T21:30:31Z"
    message: Job has reached the specified backoff limit
    reason: BackoffLimitExceeded
    status: "True"
    type: Failed
failed: 5
ready: 0
startTime: "2024-01-19T21:27:46Z"
uncountedTerminatedPods: {}
ubuntu@ip-172-31-38-158:~/kubestellar$ kc -n kubeflex-system logs pod/kubeflex-operator-rmcxh
exec /bin/sh: exec format error
ubuntu@ip-172-31-38-158:~/kubestellar$ kc -n kubeflex-system logs pod/kubeflex-operator-n8drg
exec /bin/sh: exec format error
ubuntu@ip-172-31-38-158:~/kubestellar$
```

### Images
Looks like current image of the job is for `OS/Arch: Linux, x86-64` only, as shown here: https://gallery.ecr.aws/bitnami/kubectl

I switched to another image of multi-platform as shown here: https://hub.docker.com/r/bitnami/kubectl/tags?page=1&name=1.27.8

### The Fix
After changing the image, I packed my own helm chart as https://github.com/users/waltforme/packages/container/package/kubeflex%2Fchart%2Fkubeflex-operator, complied the kflex binary which points to the helm chart, then `kflex init -c` ends up with a successful `kubeflex-operator` job.

### Discussion
I don't fully understand why I haven't got the error on my Mac with M1 chip. I guess there must be some emulation on Mac to run amd64 executable but not sure about that.