### PR TITLE
✨ Use a multi-platform image in quay.io/kubestellar for kubectl

### DIFF
--- a/chart/templates/install-hooks.yaml
+++ b/chart/templates/install-hooks.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: "{{ .Release.Name }}"
-        image: public.ecr.aws/bitnami/kubectl:1.27.8-debian-11-r0
+        image: quay.io/kubestellar/kubectl:1.27.8
         command:
         - sh
         - -c


### PR DESCRIPTION
This PR replaces #174. (Because I deleted the merging branch of #174 by mistake)

I pushed to `quay.io/kubestellar/kubectl:1.27.8` which is a multi-platform image for linux/amd64 and linux/arm64.

After merging this, do we need to update the chart ghcr.io/kubestellar/kubeflex/chart/kubeflex-operator, maybe overwrite the v0.4.0 tag? Because currently the chart refers to the ECR community image.