### PR TITLE
🐛 Upgrade kine image from v0.9.9-amd64 to v0.11.4

### DIFF
--- a/pkg/reconcilers/k8s/deployment.go
+++ b/pkg/reconcilers/k8s/deployment.go
@@ -126,7 +126,7 @@ func (r *K8sReconciler) generateAPIServerDeployment(namespace, dbName string, is
 					Containers: []v1.Container{
 						{
 							Name:    "kine",
-							Image:   "rancher/kine:v0.9.9-amd64",
+							Image:   "rancher/kine:v0.11.4",
 							Command: []string{"kine", "--endpoint", util.GeneratePGConnectionString(dbPassword, dbName)},
 							Ports: []v1.ContainerPort{{
 								ContainerPort: 2379,


### PR DESCRIPTION
## Summary

Upgrade kine image from v0.9.9-amd64 to v0.11.4 to allow kubeflex to run in linux/arm64

## Related issue(s)

Fixes #

https://github.com/kubestellar/kubeflex/issues/189
