### PR TITLE
✨ Remove OCP anyuid SCC polocy

### DIFF
--- a/cmd/kflex/init/init.go
+++ b/cmd/kflex/init/init.go
@@ -66,12 +66,6 @@ func Init(ctx context.Context, kubeconfig, version, buildDate string, domain, ex
 	ensureKFlexOperator(ctx, version, domain, externalPort, isOCP)
 	done <- true
 
-	if isOCP {
-		util.PrintStatus("Adding OpenShift anyuid SCC to kubeflex SA...", done, &wg, chattyStatus)
-		util.AddSCCtoUserPolicy("")
-		done <- true
-	}
-
 	util.PrintStatus("Waiting for kubeflex operator to become ready...", done, &wg, chattyStatus)
 	util.WaitForDeploymentReady(
 		clientset,

--- a/docs/users.md
+++ b/docs/users.md
@@ -106,13 +106,6 @@ helm upgrade --install kubeflex-operator oci://ghcr.io/kubestellar/kubeflex/char
 --set isOpenShift=true
 ```
 
-Finally, add the the OpenShift anyuid SCC to the KubeFlex service account (note that this is done
-automatically by `kflex init` if you are using the kflex CLI installer):
-
-```shell
-oc adm policy add-scc-to-user anyuid -z kubeflex-controller-manager -n kubeflex-system
-```
-
 ## Upgrading Kubeflex
 
 The KubeFlex CLI can be upgraded with `brew upgrade kubeflex` (for brew installs). For linux

--- a/pkg/util/ocp.go
+++ b/pkg/util/ocp.go
@@ -1,10 +1,6 @@
 package util
 
 import (
-	"context"
-
-	"github.com/kubestellar/kubeflex/pkg/client"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 )
@@ -38,25 +34,4 @@ func checkResourceExists(discoveryClient discovery.DiscoveryInterface, group, ve
 	}
 
 	return false, nil
-}
-
-func AddSCCtoUserPolicy(kubeconfig string) error {
-	securityClient, err := client.GetOpendShiftSecClient("")
-	if err != nil {
-		return err
-	}
-
-	anyuidSCC, err := securityClient.SecurityV1().SecurityContextConstraints().Get(context.Background(), "anyuid", metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	anyuidSCC.Users = append(anyuidSCC.Users, kubeflexServiceAccount)
-
-	_, err = securityClient.SecurityV1().SecurityContextConstraints().Update(context.Background(), anyuidSCC, metav1.UpdateOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }


### PR DESCRIPTION
## Summary

Based on the merged #204, we can now remove the use of the anyuid SCC policy that was needed to run in OCP

Please test these changes one more time on a fresh OpenShift cluster.

## Related issue(s)

Fixes #
