### PR TITLE
🐛 Try running kube-apiserver in k8s type cp as user 65534

### DIFF
--- a/pkg/reconcilers/k8s/deployment.go
+++ b/pkg/reconcilers/k8s/deployment.go
@@ -269,6 +269,7 @@ func (r *K8sReconciler) generateAPIServerDeployment(namespace, dbName string, is
 	if isOCP {
 		deployment.Spec.Template.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsNonRoot: pointer.Bool(true),
+			RunAsUser:    pointer.Int64(65534),
 			SeccompProfile: &v1.SeccompProfile{
 				Type: v1.SeccompProfileTypeRuntimeDefault,
 			},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the kube-apiserver Deployment for k8s type control planes to specify `runAsUser: 65534`, because #195 suggests that something like this is needed.

## Related issue(s)

This might be part of fixing #195 
