### PR TITLE
🐛 exit with non-zero error when context already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ bin
 dist/
 *.tgz
 .DS_Store
+
+.vscode/

--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -98,7 +98,7 @@ func (c *CPCreate) Create(controlPlaneType, backendType, hook string, hookVars [
 	done <- true
 
 	if err := kubeconfig.LoadAndMerge(c.Ctx, clientset, c.Name, controlPlaneType); err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading and merging kubeconfig: %s\n", controlPlaneType)
+		fmt.Fprintf(os.Stderr, "Error loading and merging kubeconfig: %s\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fixes bug for `kflex create wds2 -t host` fails but exits with status 0, when context wds2 pre-existing 

## Related issue(s)

Fixes #238 
