### PR TITLE
📖 add clarification on PCH behavior

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -579,6 +579,10 @@ With kflex CLI (you can use --postcreate-hook or -p):
 kflex create cp1 --postcreate-hook <my-hook-name> # e.g. kflex create cp1 -p hello
 ```
 
+While `kflex create` waits for the control plane to be available, it does not guarantee 
+the hook's completion. Use `kubectl` commands to verify the status of resources created 
+by the hook.
+
 If you are using directly a ControlPlane CRD with kubectl, you can create a control plane
 with the post-create hook as in the following example:
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add clarification that `kflex create -p` does not wait for the PCH to "complete" in any sense to the user guide.

## Related issue(s)

Fixes #237
