### PR TITLE
🐛 Fix postgres install hook role binding

### DIFF
--- a/chart/templates/postgresql.yaml
+++ b/chart/templates/postgresql.yaml
@@ -42,6 +42,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: helm-install-rolebinding
+  namespace: kubeflex-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
## Summary

When installing the helm chart without specifying the `kubeflex-system` namespace, the `helm-install-rolebinding` is created in the default namespace instead of the `kubeflex-system` namespace. This causes the postgres installation to fail

## Related issue(s)

Fixes #
