### PR TITLE
✨Add initContainer to wait for postgresql Ready status

### DIFF
--- a/chart/templates/operator.yaml
+++ b/chart/templates/operator.yaml
@@ -646,6 +646,18 @@ spec:
           capabilities:
             drop:
             - ALL
+      initContainers:
+      - args:
+        - |
+          while [[ $(kubectl get pods postgres-postgresql-0 -n kubeflex-system -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+            echo "waiting for postgresql pod"
+            sleep 5
+          done
+        command:
+        - sh
+        - -c
+        image: quay.io/kubestellar/kubectl:1.29.3
+        name: wait-postgresql
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kubeflex-controller-manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -24,6 +24,16 @@ spec:
                   operator: In
                   values:
                     - linux
+      initContainers:
+      - name: wait-postgresql
+        image: quay.io/kubestellar/kubectl:1.29.3
+        command: ['sh', '-c']
+        args:
+        - |
+          while [[ $(kubectl get pods postgres-postgresql-0 -n kubeflex-system -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+            echo "waiting for postgresql pod"
+            sleep 5
+          done
       containers:
       - name: kube-rbac-proxy
         securityContext:


### PR DESCRIPTION
## Summary

Add initContainer to wait for postgresql Ready status.
This prevent kubeflex from acting on CP CRs before the database is ready
This dramatically speedup the creation of CPs and prevent crashes.

## Related issue(s)

Fixes #
