### PR TITLE
🐛 Expose failure to switch to hosting context

### DIFF
--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -43,7 +43,7 @@ func (c *CPCreate) Create(controlPlaneType, backendType, hook string, hookVars [
 	done := make(chan bool)
 	var wg sync.WaitGroup
 	cx := cont.CPCtx{}
-	cx.Context(chattyStatus)
+	cx.Context(chattyStatus, false)
 
 	clp, err := kfclient.GetClient(c.Kubeconfig)
 	if err != nil {

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -39,7 +39,7 @@ type CPCtx struct {
 }
 
 // Context switch context in Kubeconfig
-func (c *CPCtx) Context(chattyStatus bool) {
+func (c *CPCtx) Context(chattyStatus, failIfNone bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 	kconf, err := kubeconfig.LoadKubeconfig(c.Ctx)
@@ -60,6 +60,11 @@ func (c *CPCtx) Context(chattyStatus bool) {
 				os.Exit(1)
 			}
 			done <- true
+		} else if failIfNone {
+			fmt.Fprintln(os.Stderr, "The initial (hosting) context is not known!\n"+
+				"You can make it known to kflex by doing `kubectl config use-context $name_of_hosting_context` "+
+				"and then either `kflex create ...` or `kflex ctx $some_control_plane_name")
+			os.Exit(1)
 		}
 	default:
 		ctxName := certs.GenerateContextName(c.Name)

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -116,7 +116,7 @@ var initCmd = &cobra.Command{
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a control plane instance",
-	Long: `Create a control plane instance and switches the Kubeconfig context to 
+	Long: `Create a control plane instance and switches the Kubeconfig context to
 	        the current instance`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -141,7 +141,7 @@ var createCmd = &cobra.Command{
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete a control plane instance",
-	Long: `Delete a control plane instance and switches the context back to 
+	Long: `Delete a control plane instance and switches the context back to
 	        the hosting cluster context`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -175,7 +175,7 @@ var ctxCmd = &cobra.Command{
 				Kubeconfig: kubeconfig,
 			},
 		}
-		cp.Context(chattyStatus)
+		cp.Context(chattyStatus, true)
 	},
 }
 

--- a/docs/users.md
+++ b/docs/users.md
@@ -150,7 +150,18 @@ Note that this option is ignored if you are installing on OpenShift.
 
 ## Creating a new control plane
 
-You can create a new control plane using the KubeFlex CLI or using any Kubernetes client or `kubectl`.
+You can create a new control plane using the KubeFlex CLI (`kflex`) or using any Kubernetes client or `kubectl`.
+
+**NOTE**: A pre-condition of using `kflex` to create a new control
+plane is that either (a) your kubeconfig current-context is the one
+used to access the hosting cluster or (b) the name of that context has
+been stored in an extension in your kubeconfig file (see
+[below](#hosting-context)). When this precondition is not met, the
+failure will look like the following.
+
+    $ kflex create cp1
+    ✔ Checking for saved initial context...
+    ◐ Creating new control plane cp1 of type k8s ...Error creating instance: no matches for kind "ControlPlane" in version "tenancy.kflex.kubestellar.org/v1alpha1"
 
 To create a new control plane with name `cp1` using the KubeFlex CLI:
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR make `kflex ctx` print an error message and exit with non-zero status when it fails to do its job.

## Related issue(s)

Fixes #253
