### PR TITLE
🐛 Enable the use of KubeFlex in MicroShift cluster

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,6 +5,7 @@
 domain: localtest.me
 externalPort: "9443"
 isOpenShift: "false"
+isMicroShift: "false"
 installPostgreSQL: true
 hostContainer: kubeflex-control-plane
 verbosity: 2 # must be > 0

--- a/cmd/kflex/init/init.go
+++ b/cmd/kflex/init/init.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kubestellar/kubeflex/pkg/util"
 )
 
-func Init(ctx context.Context, kubeconfig, version, buildDate string, domain, externalPort, hostContainer string, chattyStatus, isOCP bool) {
+func Init(ctx context.Context, kubeconfig, version, buildDate string, domain, externalPort, hostContainer string, chattyStatus, isOCP bool, isMicroShift bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 
@@ -63,7 +63,7 @@ func Init(ctx context.Context, kubeconfig, version, buildDate string, domain, ex
 	done <- true
 
 	util.PrintStatus("Installing kubeflex operator...", done, &wg, chattyStatus)
-	ensureKFlexOperator(ctx, version, domain, externalPort, hostContainer, isOCP)
+	ensureKFlexOperator(ctx, version, domain, externalPort, hostContainer, isOCP, isMicroShift)
 	done <- true
 
 	util.PrintStatus("Waiting for kubeflex operator to become ready...", done, &wg, chattyStatus)
@@ -116,7 +116,7 @@ func ensureSystemDB(ctx context.Context, isOCP bool) {
 	}
 }
 
-func ensureKFlexOperator(ctx context.Context, fullVersion, domain, externalPort, hostContainer string, isOCP bool) {
+func ensureKFlexOperator(ctx context.Context, fullVersion, domain, externalPort, hostContainer string, isOCP bool, isMicroShift bool) {
 	version := util.ParseVersionNumber(fullVersion)
 	vars := []string{
 		fmt.Sprintf("version=%s", version),
@@ -124,6 +124,7 @@ func ensureKFlexOperator(ctx context.Context, fullVersion, domain, externalPort,
 		fmt.Sprintf("externalPort=%s", externalPort),
 		fmt.Sprintf("hostContainer=%s", hostContainer),
 		fmt.Sprintf("isOpenShift=%s", strconv.FormatBool(isOCP)),
+		fmt.Sprintf("isMicroShift=%s", strconv.FormatBool(isMicroShift)),
 		"installPostgreSQL=false",
 	}
 	h := &helm.HelmHandler{

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -49,6 +49,7 @@ var Hook string
 var domain string
 var externalPort int
 var chattyStatus bool
+var isMicroShift bool
 var hookVars []string
 var hostContainer string
 
@@ -108,7 +109,7 @@ var initCmd = &cobra.Command{
 			}
 			cluster.CreateKindCluster(chattyStatus)
 		}
-		in.Init(ctx, kubeconfig, Version, BuildDate, domain, strconv.Itoa(externalPort), hostContainer, chattyStatus, isOCP)
+		in.Init(ctx, kubeconfig, Version, BuildDate, domain, strconv.Itoa(externalPort), hostContainer, chattyStatus, isOCP, isMicroShift)
 		wg.Wait()
 	},
 }
@@ -116,7 +117,7 @@ var initCmd = &cobra.Command{
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a control plane instance",
-	Long: `Create a control plane instance and switches the Kubeconfig context to 
+	Long: `Create a control plane instance and switches the Kubeconfig context to
 	        the current instance`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -141,7 +142,7 @@ var createCmd = &cobra.Command{
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete a control plane instance",
-	Long: `Delete a control plane instance and switches the context back to 
+	Long: `Delete a control plane instance and switches the context back to
 	        the hosting cluster context`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -190,6 +191,7 @@ func init() {
 	initCmd.Flags().StringVarP(&hostContainer, "hostContainerName", "n", "kubeflex-control-plane", "Name of the hosting cluster container (kind or k3d only)")
 	initCmd.Flags().IntVarP(&externalPort, "externalPort", "p", 9443, "external port used by ingress")
 	initCmd.Flags().BoolVarP(&chattyStatus, "chatty-status", "s", true, "chatty status indicator")
+	initCmd.Flags().BoolVarP(&isMicroShift, "isMicroShift", "", false, "set it to true for MicroShift clusters")
 
 	createCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to kubeconfig file")
 	createCmd.Flags().IntVarP(&verbosity, "verbosity", "v", 0, "log level") // TODO - figure out how to inject verbosity

--- a/config/manager/config.yaml
+++ b/config/manager/config.yaml
@@ -7,4 +7,5 @@ data:
   domain: "{{ .Values.domain }}"
   externalPort: "{{ .Values.externalPort }}"
   isOpenShift: "{{ .Values.isOpenShift }}"
+  isMicroShift: "{{ .Values.isMicroShift }}"
   hostContainer: "{{ .Values.hostContainer }}"

--- a/pkg/reconcilers/k8s/reconciler.go
+++ b/pkg/reconcilers/k8s/reconciler.go
@@ -108,7 +108,7 @@ func (r *K8sReconciler) Reconcile(ctx context.Context, hcp *v1alpha1.ControlPlan
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 
-	if err = r.ReconcileAPIServerDeployment(ctx, hcp, cfg.IsOpenShift); err != nil {
+	if err = r.ReconcileAPIServerDeployment(ctx, hcp, cfg.IsOpenShift, cfg.IsMicroShift); err != nil {
 		return r.UpdateStatusForSyncingError(hcp, err)
 	}
 

--- a/pkg/reconcilers/shared/reconciler.go
+++ b/pkg/reconcilers/shared/reconciler.go
@@ -53,6 +53,7 @@ type SharedConfig struct {
 	Domain        string
 	HostContainer string
 	IsOpenShift   bool
+	IsMicroShift  bool
 	ExternalURL   string
 }
 
@@ -94,11 +95,16 @@ func (r *BaseReconciler) GetConfig(ctx context.Context) (*SharedConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	isMicroShift, err := strconv.ParseBool(cmap.Data["isMicroShift"])
+	if err != nil {
+		return nil, err
+	}
 	return &SharedConfig{
 		Domain:        cmap.Data["domain"],
 		HostContainer: cmap.Data["hostContainer"],
 		ExternalPort:  port,
 		IsOpenShift:   isOpenShift,
+		IsMicroShift:  isMicroShift,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Add a new `isMicroShift` chart value to let the controller know that when creating a `k8s` control plane in a MicroShift cluster a `runAsUser` value is needed.

## Related issue(s)

Fixes #
#195 