### PR TITLE
🐛 fix IsClusterScoped function not correctly handling empty API group

### DIFF
--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -111,7 +111,11 @@ func GenerateObjectInfoString(obj unstructured.Unstructured) string {
 
 func IsClusterScoped(gvk schema.GroupVersionKind, apiResourceLists []*metav1.APIResourceList) (bool, error) {
 	for _, resourceList := range apiResourceLists {
-		if resourceList.GroupVersion == gvk.Group+"/"+gvk.Version {
+		groupVersion := gvk.Group + "/" + gvk.Version
+		if gvk.Group == "" {
+			groupVersion = gvk.Version
+		}
+		if resourceList.GroupVersion == groupVersion {
 			for _, apiResource := range resourceList.APIResources {
 				if apiResource.Kind == gvk.Kind {
 					if apiResource.Namespaced {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

fix IsClusterScoped function not correctly handling empty API group

## Related issue(s)

Fixes #278 
