### PR TITLE
✨ more forceful kflex ctx commands

### DIFF
--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -38,12 +38,12 @@ type CPCreate struct {
 	common.CP
 }
 
-// Create a ne control plane
+// Create a new control plane
 func (c *CPCreate) Create(controlPlaneType, backendType, hook string, hookVars []string, chattyStatus bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 	cx := cont.CPCtx{}
-	cx.Context(chattyStatus, false)
+	cx.Context(chattyStatus, false, false, false)
 
 	clp, err := kfclient.GetClient(c.Kubeconfig)
 	if err != nil {

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -40,7 +40,7 @@ type CPCtx struct {
 }
 
 // Context switch context in Kubeconfig
-func (c *CPCtx) Context(chattyStatus, failIfNone, forceCtxAsHosting, setCurrentCtxAsHosting bool) {
+func (c *CPCtx) Context(chattyStatus, failIfNone, overwriteExistingCtx, setCurrentCtxAsHosting bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 	kconf, err := kubeconfig.LoadKubeconfig(c.Ctx)
@@ -76,37 +76,43 @@ func (c *CPCtx) Context(chattyStatus, failIfNone, forceCtxAsHosting, setCurrentC
 			done <- true
 		}
 	default:
-		// handle the force hostig cluster flag first
-		if forceCtxAsHosting {
-			util.PrintStatus("Forcing setting hosting cluster context", done, &wg, chattyStatus)
-			kubeconfig.SetHostingClusterContextPreference(kconf, &c.Name)
-			done <- true
-		} else { // handle switching context
-			ctxName := certs.GenerateContextName(c.Name)
-			util.PrintStatus(fmt.Sprintf("Switching to context %s...", ctxName), done, &wg, chattyStatus)
-			if err = kubeconfig.SwitchContext(kconf, c.Name); err != nil {
-				fmt.Fprintf(os.Stderr, "kubeconfig context %s not found (%s), trying to load from server...\n", c.Name, err)
-				if err := c.switchToHostingClusterContextAndWrite(kconf); err != nil {
-					fmt.Fprintf(os.Stderr, "Error switching back to hosting cluster context: %s\n", err)
-					os.Exit(1)
-				}
-				if err = c.loadAndMergeFromServer(kconf); err != nil {
-					fmt.Fprintf(os.Stderr, "Error loading kubeconfig context from server: %s\n", err)
-					os.Exit(1)
-				}
-				// context exists only for CPs that are not of type host
-				if c.Type != tenancyv1alpha1.ControlPlaneTypeHost {
-					if err = kubeconfig.SwitchContext(kconf, c.Name); err != nil {
-						fmt.Fprintf(os.Stderr, "Error switching kubeconfig context after loading from server: %s\n", err)
-						os.Exit(1)
-					}
-				} else {
-					fmt.Fprintf(os.Stderr, "control plane %s is of type 'host', using hosting cluster context (%s)\n", c.Name, kconf.CurrentContext)
-					os.Exit(0)
-				}
+		ctxName := certs.GenerateContextName(c.Name)
+		if overwriteExistingCtx {
+			util.PrintStatus("Overwriting existing context for control plane", done, &wg, chattyStatus)
+			if err = kubeconfig.DeleteContext(kconf, c.Name); err != nil {
+				fmt.Fprintf(os.Stderr, "no kubeconfig context for %s was found: %s\n", c.Name, err)
 			}
 			done <- true
 		}
+
+		util.PrintStatus(fmt.Sprintf("Switching to context %s...", ctxName), done, &wg, chattyStatus)
+		if err = kubeconfig.SwitchContext(kconf, c.Name); err != nil {
+			if overwriteExistingCtx {
+				fmt.Fprintf(os.Stderr, "trying to load new context %s from server...\n", c.Name)
+			} else {
+				fmt.Fprintf(os.Stderr, "kubeconfig context %s not found (%s), trying to load from server...\n", c.Name, err)
+			}
+			if err := c.switchToHostingClusterContextAndWrite(kconf); err != nil {
+				fmt.Fprintf(os.Stderr, "Error switching back to hosting cluster context: %s\n", err)
+				os.Exit(1)
+			}
+			if err = c.loadAndMergeFromServer(kconf); err != nil {
+				fmt.Fprintf(os.Stderr, "Error loading kubeconfig context from server: %s\n", err)
+				os.Exit(1)
+			}
+			// context exists only for CPs that are not of type host
+			if c.Type != tenancyv1alpha1.ControlPlaneTypeHost {
+				if err = kubeconfig.SwitchContext(kconf, c.Name); err != nil {
+					fmt.Fprintf(os.Stderr, "Error switching kubeconfig context after loading from server: %s\n", err)
+					os.Exit(1)
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "control plane %s is of type 'host', using hosting cluster context (%s)\n", c.Name, kconf.CurrentContext)
+				os.Exit(0)
+			}
+		}
+		done <- true
+
 	}
 
 	if err = kubeconfig.WriteKubeconfig(c.Ctx, kconf); err != nil {

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -67,8 +67,9 @@ func (c *CPCtx) Context(chattyStatus, failIfNone, overwriteExistingCtx, setCurre
 		} else if failIfNone {
 			if !c.isCurrentContextHostingClusterContext() {
 				fmt.Fprintln(os.Stderr, "The hosting cluster context is not known!\n"+
-					"You can make it known to kflex by doing `kubectl ctx --force-replace-for-hosting $name_of_hosting_context` "+
-					"or  `kubectl ctx --set-current-for-hosting` ...`")
+					"You can make it known to kflex by doing `kubectl config use-context` \n"+
+					"to set the current context to the hosting cluster context and then using \n"+
+					"`kflex ctx --set-current-for-hosting` to restore the needed kubeconfig extension.")
 				os.Exit(1)
 			}
 			util.PrintStatus("Hosting cluster context not set, setting it to current context", done, &wg, chattyStatus)

--- a/cmd/kflex/delete/delete.go
+++ b/cmd/kflex/delete/delete.go
@@ -50,7 +50,8 @@ func (c *CPDelete) Delete(chattyStatus bool) {
 	}
 
 	if err = kubeconfig.SwitchToHostingClusterContext(kconf, false); err != nil {
-		fmt.Fprintf(os.Stderr, "no initial kubeconfig context was found: %s\n", err)
+		fmt.Fprintf(os.Stderr, "error switching to hosting cluster kubeconfig context: %s\n", err)
+		os.Exit(1)
 	}
 
 	if err = kubeconfig.DeleteContext(kconf, c.Name); err != nil {

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -51,7 +51,7 @@ var externalPort int
 var chattyStatus bool
 var hookVars []string
 var hostContainer string
-var forceCtxAsHosting bool
+var overwriteExistingCtx bool
 var setCurrentCtxAsHosting bool
 
 // defaults
@@ -177,7 +177,7 @@ var ctxCmd = &cobra.Command{
 				Kubeconfig: kubeconfig,
 			},
 		}
-		cp.Context(chattyStatus, true, forceCtxAsHosting, setCurrentCtxAsHosting)
+		cp.Context(chattyStatus, true, overwriteExistingCtx, setCurrentCtxAsHosting)
 	},
 }
 
@@ -208,7 +208,7 @@ func init() {
 	ctxCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to kubeconfig file")
 	ctxCmd.Flags().IntVarP(&verbosity, "verbosity", "v", 0, "log level") // TODO - figure out how to inject verbosity
 	ctxCmd.Flags().BoolVarP(&chattyStatus, "chatty-status", "s", true, "chatty status indicator")
-	ctxCmd.Flags().BoolVarP(&forceCtxAsHosting, "force-replace-for-hosting", "f", false, "Force replace of hosting cluster context with supplied context")
+	ctxCmd.Flags().BoolVarP(&overwriteExistingCtx, "overwrite-existing-context", "o", false, "Overwrite of hosting cluster context with new control plane context")
 	ctxCmd.Flags().BoolVarP(&setCurrentCtxAsHosting, "set-current-for-hosting", "c", false, "Set current context as hosting cluster context")
 
 	rootCmd.AddCommand(versionCmd)

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -51,6 +51,8 @@ var externalPort int
 var chattyStatus bool
 var hookVars []string
 var hostContainer string
+var forceCtxAsHosting bool
+var setCurrentCtxAsHosting bool
 
 // defaults
 const BKTypeDefault = string(tenancyv1alpha1.BackendDBTypeShared)
@@ -175,7 +177,7 @@ var ctxCmd = &cobra.Command{
 				Kubeconfig: kubeconfig,
 			},
 		}
-		cp.Context(chattyStatus, true)
+		cp.Context(chattyStatus, true, forceCtxAsHosting, setCurrentCtxAsHosting)
 	},
 }
 
@@ -206,6 +208,8 @@ func init() {
 	ctxCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to kubeconfig file")
 	ctxCmd.Flags().IntVarP(&verbosity, "verbosity", "v", 0, "log level") // TODO - figure out how to inject verbosity
 	ctxCmd.Flags().BoolVarP(&chattyStatus, "chatty-status", "s", true, "chatty status indicator")
+	ctxCmd.Flags().BoolVarP(&forceCtxAsHosting, "force-replace-for-hosting", "f", false, "Force replace of hosting cluster context with supplied context")
+	ctxCmd.Flags().BoolVarP(&setCurrentCtxAsHosting, "set-current-for-hosting", "c", false, "Set current context as hosting cluster context")
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)

--- a/docs/users.md
+++ b/docs/users.md
@@ -187,6 +187,15 @@ kflex ctx
 
 That command requires your kubeconfig file to hold an extension that `kflex init` created to hold the name of the hosting cluster context. See [below](#hosting-context) for more information.
 
+To update or refresh outdated or corrupted context information for a control plane stored in 
+the kubeconfig file, you can forcefully reload and overwrite the existing context data from 
+the KubeFlex hosting cluster. This can be accomplished by using the `--overwrite-existing-context` 
+flag. Here is an example:
+
+```shell
+kflex ctx cp1 --overwrite-existing-context
+```
+
 To switch back to a control plane context, use the
 `ctx <control plane name>` command, e.g:
 
@@ -718,9 +727,8 @@ You can do this in either of the two following ways.
 
 If the relevant extension is missing then you can restore it by using
 `kubectl config use-context` to set the current context to the hosting
-cluster context and then using `kflex ctx $cpname` to switch to
-another context. In the course of doing that, `kflex` will restore the
-needed kubeconfig extension.
+cluster context and then using `kflex ctx --set-current-for-hosting` 
+to restore the needed kubeconfig extension.
 
 ### Restore Hosting Context Preference by editing kubeconfig file
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Provides new flags for  the`kflex ctx` command:
- `--overwrite-existing-context`
- `--set-current-for-hosting`
to help with those cases where hosting cluster context stored in kubeconfig is invalid.


Fixes #288 
