### PR TITLE
✨ Use postgresql chart and image from quay.io

### DIFF
--- a/chart/templates/postgresql.yaml
+++ b/chart/templates/postgresql.yaml
@@ -94,7 +94,7 @@ spec:
           - upgrade
           - --install
           - postgres
-          - oci://registry-1.docker.io/bitnamicharts/postgresql
+          - oci://quay.io/kubestellar/charts/postgresql
           - --version
           - 13.1.5
           - --namespace


### PR DESCRIPTION
## Summary

KubeFlex chart was changed to use PostgreSQL chart stored in Quay.io: `oci://quay.io/kubestellar/charts/postgresq:13.1.5`

The chart is a copy of the original `oci://registry-1.docker.io/bitnamicharts/postgresql:13.1.5` but pointing to the container image in quay at `quay.io/kubestellar/postgresql/16.0.0-debian-11-r13` which is a multi-arch (amd64/arm64) copy of the original image at `docker.io/bitnami/postgresql:16.0.0-debian-11-r13`.

The main objective of this PR is to avoid hitting Docker pull request limit, especially during testing.

## Related issue(s)

Fixes #
