### PR TITLE
🐛  Fix sharing, enqueuing, and logging bugs

### DIFF
--- a/internal/controller/controlplane_controller.go
+++ b/internal/controller/controlplane_controller.go
@@ -192,7 +192,7 @@ func enqueueSecretsOfInterest(logger logr.Logger) handler.EventHandler {
 		}
 
 		// Check if the secret has the specified name
-		if secret.Name != util.VClusterKubeConfigSecret {
+		if secret.Name == util.VClusterKubeConfigSecret {
 			cpName, err := util.ControlPlaneNameFromNamespace(secret.Namespace)
 			if err == nil {
 				return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: cpName}}}

--- a/pkg/reconcilers/external/reconciler.go
+++ b/pkg/reconcilers/external/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,13 +36,14 @@ type ExternalReconciler struct {
 	*shared.BaseReconciler
 }
 
-func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient) *ExternalReconciler {
+func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, eventRecorder record.EventRecorder) *ExternalReconciler {
 	return &ExternalReconciler{
 		BaseReconciler: &shared.BaseReconciler{
 			Client:        cl,
 			Scheme:        scheme,
 			ClientSet:     clientSet,
 			DynamicClient: dynamicClient,
+			EventRecorder: eventRecorder,
 		},
 	}
 }

--- a/pkg/reconcilers/host/reconciler.go
+++ b/pkg/reconcilers/host/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,13 +38,14 @@ type HostReconciler struct {
 	*shared.BaseReconciler
 }
 
-func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient) *HostReconciler {
+func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, eventRecorder record.EventRecorder) *HostReconciler {
 	return &HostReconciler{
 		BaseReconciler: &shared.BaseReconciler{
 			Client:        cl,
 			Scheme:        scheme,
 			ClientSet:     clientSet,
 			DynamicClient: dynamicClient,
+			EventRecorder: eventRecorder,
 		},
 	}
 }

--- a/pkg/reconcilers/k8s/reconciler.go
+++ b/pkg/reconcilers/k8s/reconciler.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -38,13 +39,14 @@ type K8sReconciler struct {
 	*shared.BaseReconciler
 }
 
-func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient) *K8sReconciler {
+func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, eventRecorder record.EventRecorder) *K8sReconciler {
 	return &K8sReconciler{
 		BaseReconciler: &shared.BaseReconciler{
 			Client:        cl,
 			Scheme:        scheme,
 			ClientSet:     clientSet,
 			DynamicClient: dynamicClient,
+			EventRecorder: eventRecorder,
 		},
 	}
 }

--- a/pkg/reconcilers/ocm/reconciler.go
+++ b/pkg/reconcilers/ocm/reconciler.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -40,13 +41,14 @@ type OCMReconciler struct {
 	*shared.BaseReconciler
 }
 
-func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient) *OCMReconciler {
+func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, eventRecorder record.EventRecorder) *OCMReconciler {
 	return &OCMReconciler{
 		BaseReconciler: &shared.BaseReconciler{
 			Client:        cl,
 			Scheme:        scheme,
 			ClientSet:     clientSet,
 			DynamicClient: dynamicClient,
+			EventRecorder: eventRecorder,
 		},
 	}
 }

--- a/pkg/reconcilers/shared/postcreate_hook.go
+++ b/pkg/reconcilers/shared/postcreate_hook.go
@@ -133,7 +133,7 @@ func applyPostCreateHook(ctx context.Context, clientSet *kubernetes.Clientset, d
 			return err
 		}
 
-		logger.Info("Applying", "object", util.GenerateObjectInfoString(*obj))
+		logger.Info("Applying", "object", util.GenerateObjectInfoString(*obj), "cpNamespace", namespace)
 
 		if clusterScoped {
 			setTrackingLabelsAndAnnotations(obj, hcp.Name)

--- a/pkg/reconcilers/shared/rbac.go
+++ b/pkg/reconcilers/shared/rbac.go
@@ -18,6 +18,7 @@ package shared
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kubestellar/kubeflex/pkg/util"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -25,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	clog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 )
@@ -35,7 +35,6 @@ const (
 )
 
 func (r *BaseReconciler) ReconcileUpdateClusterInfoJobRole(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
-	_ = clog.FromContext(ctx)
 	namespace := util.GenerateNamespaceFromControlPlaneName(hcp.Name)
 
 	// create role object
@@ -46,14 +45,14 @@ func (r *BaseReconciler) ReconcileUpdateClusterInfoJobRole(ctx context.Context, 
 		},
 	}
 
-	err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(role), role, &client.GetOptions{})
+	err := r.Client.Get(ctx, client.ObjectKeyFromObject(role), role, &client.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			role := generateClusterInfoJobRole(roleName, namespace)
 			if err := controllerutil.SetControllerReference(hcp, role, r.Scheme); err != nil {
-				return nil
+				return fmt.Errorf("failed to SetControllerReference: %w", err)
 			}
-			err = r.Client.Create(context.TODO(), role, &client.CreateOptions{})
+			err = r.Client.Create(ctx, role, &client.CreateOptions{})
 			if err != nil {
 				return err
 			}
@@ -90,7 +89,6 @@ func generateClusterInfoJobRole(name, namespace string) *rbacv1.Role {
 }
 
 func (r *BaseReconciler) ReconcileUpdateClusterInfoJobRoleBinding(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) error {
-	_ = clog.FromContext(ctx)
 	namespace := util.GenerateNamespaceFromControlPlaneName(hcp.Name)
 
 	// create role binding object
@@ -101,14 +99,14 @@ func (r *BaseReconciler) ReconcileUpdateClusterInfoJobRoleBinding(ctx context.Co
 		},
 	}
 
-	err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(binding), binding, &client.GetOptions{})
+	err := r.Client.Get(ctx, client.ObjectKeyFromObject(binding), binding, &client.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			binding := generateClusterInfoJobRoleBinding(roleName, namespace)
 			if err := controllerutil.SetControllerReference(hcp, binding, r.Scheme); err != nil {
-				return nil
+				return fmt.Errorf("failed to SetControllerReference: %w", err)
 			}
-			err = r.Client.Create(context.TODO(), binding, &client.CreateOptions{})
+			err = r.Client.Create(ctx, binding, &client.CreateOptions{})
 			if err != nil {
 				return err
 			}

--- a/pkg/reconcilers/shared/reconciler.go
+++ b/pkg/reconcilers/shared/reconciler.go
@@ -60,7 +60,7 @@ type SharedConfig struct {
 
 func (r *BaseReconciler) UpdateStatusForSyncingError(hcp *tenancyv1alpha1.ControlPlane, e error) (ctrl.Result, error) {
 	if r.EventRecorder != nil {
-		r.EventRecorder.Event(hcp, "Warning", "syncFail", e.Error())
+		r.EventRecorder.Event(hcp, "Warning", "SyncFail", e.Error())
 	}
 	tenancyv1alpha1.EnsureCondition(hcp, tenancyv1alpha1.ConditionReconcileError(e))
 	err := r.Status().Update(context.Background(), hcp)
@@ -72,7 +72,7 @@ func (r *BaseReconciler) UpdateStatusForSyncingError(hcp *tenancyv1alpha1.Contro
 
 func (r *BaseReconciler) UpdateStatusForSyncingSuccess(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
 	if r.EventRecorder != nil {
-		r.EventRecorder.Event(hcp, "Normal", "syncSuccess", "")
+		r.EventRecorder.Event(hcp, "Normal", "SyncSuccess", "")
 	}
 	_ = clog.FromContext(ctx)
 	tenancyv1alpha1.EnsureCondition(hcp, tenancyv1alpha1.ConditionReconcileSuccess())

--- a/pkg/reconcilers/vcluster/chart.go
+++ b/pkg/reconcilers/vcluster/chart.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	configs = []string{
+	configsBase = []string{
 		"vcluster.image=rancher/k3s:v1.27.2-k3s1",
 	}
 )
@@ -47,6 +47,7 @@ func (r *VClusterReconciler) ReconcileChart(ctx context.Context, hcp *tenancyv1a
 	_ = clog.FromContext(ctx)
 	dnsName := util.GenerateDevLocalDNSName(hcp.Name, cfg.Domain)
 	port := cfg.ExternalPort
+	configs := append([]string{}, configsBase...)
 	if cfg.ExternalURL != "" {
 		dnsName = cfg.ExternalURL
 		port = 443

--- a/pkg/reconcilers/vcluster/reconciler.go
+++ b/pkg/reconcilers/vcluster/reconciler.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -46,13 +47,14 @@ type VClusterReconciler struct {
 	*shared.BaseReconciler
 }
 
-func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient) *VClusterReconciler {
+func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, eventRecorder record.EventRecorder) *VClusterReconciler {
 	return &VClusterReconciler{
 		BaseReconciler: &shared.BaseReconciler{
 			Client:        cl,
 			Scheme:        scheme,
 			ClientSet:     clientSet,
 			DynamicClient: dynamicClient,
+			EventRecorder: eventRecorder,
 		},
 	}
 }

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -95,7 +95,8 @@ func RenderYAML(yamlTemplate []byte, data interface{}) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-// Used for generating a single string unique representation of the object for logging info
+// Used for generating a single string unique representation of the object for logging info.
+// Namespace is not mentioned because the caller does not provide it.
 func GenerateObjectInfoString(obj unstructured.Unstructured) string {
 	group := obj.GetObjectKind().GroupVersionKind().Group
 	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
@@ -106,7 +107,7 @@ func GenerateObjectInfoString(obj unstructured.Unstructured) string {
 
 	}
 
-	return fmt.Sprintf("[%s] %s/%s", obj.GetNamespace(), prefix, obj.GetName())
+	return fmt.Sprintf("%s/%s", prefix, obj.GetName())
 }
 
 func IsClusterScoped(gvk schema.GroupVersionKind, apiResourceLists []*metav1.APIResourceList) (bool, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -45,10 +45,21 @@ const (
 	KubeconfigSecretKeyInCluster         = "kubeconfig-incluster"
 	KubeconfigSecretKeyVCluster          = "config"
 	KubeconfigSecretKeyVClusterInCluster = "config-incluster"
+	NamespaceSuffix                      = "-system"
 )
 
 func GenerateNamespaceFromControlPlaneName(name string) string {
-	return fmt.Sprintf("%s-system", name)
+	return name + NamespaceSuffix
+}
+
+func ControlPlaneNameFromNamespace(nsName string) (string, error) {
+	const suffixLen = len(NamespaceSuffix)
+	nsLen := len(nsName)
+	cpLen := nsLen - suffixLen
+	if cpLen > 0 && nsName[cpLen:] == NamespaceSuffix {
+		return nsName[:cpLen], nil
+	}
+	return "", fmt.Errorf("namespace %q does not end with %q", nsName, NamespaceSuffix)
 }
 
 // GenerateDevLocalDNSName: generates the local dns name for test/dev


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes three issues.

1. Wrong reference to ControlPlane derived from vc-vcluster Secret.
2. Misuse of a global variable.
3. Logging gaps/bugs.

This PR also adds Event logging for ControlPlane sync results, which should be helpful in the case of transient syncing problems. Issue #318 has a transient sync failure that lasts for a highly variable amount of time. In particular, sometimes it is long enough to cause https://github.com/kubestellar/kubestellar/issues/2717 --- and yet be gone by the time someone investigates.

## Related issue(s)

Fixes #318 
Fixes #322 
Fixes #321 


