### PR TITLE
🐛 fix: update observedGeneration to match generation in ControlPlane …

### DIFF
--- a/internal/controller/controlplane_controller.go
+++ b/internal/controller/controlplane_controller.go
@@ -115,6 +115,15 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	hcp := hostedControlPlane.DeepCopy()
 
+	// Update observedGeneration if it doesn't match the current generation
+	if hcp.Status.ObservedGeneration != hcp.Generation {
+		hcp.Status.ObservedGeneration = hcp.Generation
+		if err := r.Status().Update(ctx, hcp); err != nil {
+			log.Error(err, "Failed to update ControlPlane status with observedGeneration")
+			return ctrl.Result{}, err
+		}
+	}
+
 	// finalizer logic
 	if hcp.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(hcp, kfFinalizer) {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `kubectl wait` command times out when waiting for conditions like `Synced` or `Ready` on a `ControlPlane` resource. The root cause is that the `.status.observedGeneration` field is not being updated to match `.metadata.generation`, causing the controller to appear out of sync.

The changes include:
- Updating the `Reconcile` function in `controllers/controlplane_controller.go` to ensure `.status.observedGeneration` is set to `.metadata.generation` when the resource is processed.
- No changes were required for the CRD definition, as the `observedGeneration` field is already correctly defined.

Fixes: #300 