### PR TITLE
:sparkles: Add kflex command/flag to get the current context

### DIFF
--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -50,6 +50,14 @@ func (c *CPCtx) Context(chattyStatus, failIfNone, overwriteExistingCtx, setCurre
 	}
 
 	switch c.CP.Name {
+	case "get":
+		currentContext, err := kubeconfig.GetCurrentContext(c.Ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(currentContext)
+		return
 	case "":
 		if setCurrentCtxAsHosting { // set hosting cluster context unconditionally to the current context
 			kubeconfig.SetHostingClusterContextPreference(kconf, nil)
@@ -113,7 +121,6 @@ func (c *CPCtx) Context(chattyStatus, failIfNone, overwriteExistingCtx, setCurre
 			}
 		}
 		done <- true
-
 	}
 
 	if err = kubeconfig.WriteKubeconfig(c.Ctx, kconf); err != nil {
@@ -180,4 +187,13 @@ func (c *CPCtx) isCurrentContextHostingClusterContext() bool {
 	}
 	clientset := *clientsetp
 	return util.CheckResourceExists(clientset, "tenancy.kflex.kubestellar.org", "v1alpha1", "controlplanes")
+}
+
+func (c *CPCtx) GetCurrentContext() {
+    currentContext, err := kubeconfig.GetCurrentContext(c.Ctx)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)
+        os.Exit(1)
+    }
+    fmt.Println(currentContext)
 }

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -186,12 +186,28 @@ var deleteCmd = &cobra.Command{
 	},
 }
 
+var ctxGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get the current kubeconfig context",
+	Long:  `Retrieve and display the current context from the kubeconfig file`,
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		cp := cont.CPCtx{
+			CP: common.CP{
+				Ctx:        createContext(),
+				Kubeconfig: kubeconfig,
+			},
+		}
+		cp.GetCurrentContext()
+	},
+}
+
 var ctxCmd = &cobra.Command{
 	Use:   "ctx",
-	Short: "Switch kubeconfig context to a control plane instance",
+	Short: "Switch or get kubeconfig context",
 	Long: `Running without an argument switches the context back to the hosting cluster context,
 			        while providing the control plane name as argument switches the context to
-					that control plane`,
+					that control plane. Use 'get' to retrieve the current context.`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		cpName := ""
@@ -248,6 +264,8 @@ func init() {
 	ctxCmd.Flags().BoolVarP(&chattyStatus, "chatty-status", "s", true, "chatty status indicator")
 	ctxCmd.Flags().BoolVarP(&overwriteExistingCtx, "overwrite-existing-context", "o", false, "Overwrite of hosting cluster context with new control plane context")
 	ctxCmd.Flags().BoolVarP(&setCurrentCtxAsHosting, "set-current-for-hosting", "c", false, "Set current context as hosting cluster context")
+
+	ctxCmd.AddCommand(ctxGetCmd)
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -219,3 +219,11 @@ func renameKey(m interface{}, oldKey string, newKey string) interface{} {
 	}
 	return m
 }
+
+func GetCurrentContext(ctx context.Context) (string, error) {
+    kconf, err := LoadKubeconfig(ctx)
+    if err != nil {
+        return "", fmt.Errorf("error loading kubeconfig: %v", err)
+    }
+    return kconf.CurrentContext, nil
+}


### PR DESCRIPTION
## Summary

This PR adds a new subcommand `get` under the `ctx` command to retrieve and display the current context from the kubeconfig file. The changes include:

1. Added a new function `GetCurrentContext` in `pkg/kubeconfig/kubeconfig.go` to retrieve the current context.
2. Added a new method `GetCurrentContext` in `cmd/kflex/ctx/ctx.go` to handle the `get` subcommand.
3. Updated `main.go` to include the `get` subcommand under `ctxCmd`.

Fixes #165