### PR TITLE
✨ feature: add new subcommand list-ctx to show all kubeconfig contexts

### DIFF
--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -58,6 +58,9 @@ func (c *CPCtx) Context(chattyStatus, failIfNone, overwriteExistingCtx, setCurre
 		}
 		fmt.Println(currentContext)
 		return
+	case "list":
+		c.ListContexts()
+		return
 	case "":
 		if setCurrentCtxAsHosting { // set hosting cluster context unconditionally to the current context
 			kubeconfig.SetHostingClusterContextPreference(kconf, nil)
@@ -190,10 +193,22 @@ func (c *CPCtx) isCurrentContextHostingClusterContext() bool {
 }
 
 func (c *CPCtx) GetCurrentContext() {
-    currentContext, err := kubeconfig.GetCurrentContext(c.Ctx)
-    if err != nil {
-        fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)
-        os.Exit(1)
-    }
-    fmt.Println(currentContext)
+	currentContext, err := kubeconfig.GetCurrentContext(c.Ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(currentContext)
+}
+
+func (c *CPCtx) ListContexts() {
+	kconf, err := kubeconfig.LoadKubeconfig(c.Ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading kubeconfig: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Available contexts:")
+	for ctxName := range kconf.Contexts {
+		fmt.Printf("  %s\n", ctxName)
+	}
 }

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -32,8 +32,8 @@ import (
 	cont "github.com/kubestellar/kubeflex/cmd/kflex/ctx"
 	del "github.com/kubestellar/kubeflex/cmd/kflex/delete"
 	in "github.com/kubestellar/kubeflex/cmd/kflex/init"
-	"github.com/kubestellar/kubeflex/cmd/kflex/list"
 	cluster "github.com/kubestellar/kubeflex/cmd/kflex/init/cluster"
+	"github.com/kubestellar/kubeflex/cmd/kflex/list"
 	"github.com/kubestellar/kubeflex/pkg/client"
 	"github.com/kubestellar/kubeflex/pkg/util"
 	"github.com/spf13/cobra"
@@ -240,6 +240,21 @@ var listCmd = &cobra.Command{
 	},
 }
 
+var listCtxCmd = &cobra.Command{
+	Use:   "list-ctx",
+	Short: "List all available kubeconfig contexts",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Construct your CPCtx or retrieve it from global options
+		cpCtx := cont.CPCtx{
+			CP: common.CP{
+				Ctx:        createContext(),
+				Kubeconfig: kubeconfig,
+			},
+		}
+		cpCtx.ListContexts()
+	},
+}
+
 func init() {
 	versionCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to the kubeconfig file for the KubeFlex hosting cluster. If not specified, and $KUBECONFIG is set, it uses the value in $KUBECONFIG, otherwise it falls back to ${HOME}/.kube/configg")
 	versionCmd.Flags().BoolVarP(&chattyStatus, "chatty-status", "s", true, "chatty status indicator")
@@ -289,6 +304,7 @@ func init() {
 	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(ctxCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(listCtxCmd)
 }
 
 // TODO - work on passing the verbosity to the logger


### PR DESCRIPTION

Fixes #166
## Summary
I fixed on cmd/ctx/ctx.go file to create a new function to list all the contexts and then also fixed on the cmd/list/main.go to add the function init file. 

Here is the example what will list-ctx look likes:

 ./kflex list-ctx
Available contexts:
  minikube
  wds1
  its1


