### PR TITLE
✨ feature: Add support for alternative kubeconfig naming in ctx command

### DIFF
--- a/cmd/kflex/common/cp.go
+++ b/cmd/kflex/common/cp.go
@@ -31,6 +31,7 @@ type CP struct {
 	Ctx        context.Context
 	Kubeconfig string
 	Name       string
+	AltName    string
 }
 
 func GenerateControlPlane(name, controlPlaneType, backendType, hook string, hookVars []string, tokenExpirationSeconds *int64) (*tenancyv1alpha1.ControlPlane, error) {

--- a/cmd/kflex/delete/delete.go
+++ b/cmd/kflex/delete/delete.go
@@ -90,7 +90,7 @@ func (c *CPDelete) Delete(chattyStatus bool) {
 
 	if cp.Spec.Type != tenancyv1alpha1.ControlPlaneTypeHost &&
 		cp.Spec.Type != tenancyv1alpha1.ControlPlaneTypeExternal {
-		if err := kubeconfig.DeleteContext(kconf, c.Name); err != nil {
+		if err := kubeconfig.DeleteContext(kconf, c.Name, ""); err != nil {
 			fmt.Fprintf(os.Stderr, "no kubeconfig context for %s was found: %s\n", c.Name, err)
 			os.Exit(1)
 		}

--- a/pkg/certs/kconfig_gen.go
+++ b/pkg/certs/kconfig_gen.go
@@ -174,15 +174,24 @@ func (c *ConfigGen) generateServerEndpoint() string {
 	return fmt.Sprintf("https://%s:%d", util.GenerateDevLocalDNSName(c.CpName, c.CpDomain), c.CpPort)
 }
 
-func GenerateClusterName(cpName string) string {
+func GenerateClusterName(cpName string, altName ...string) string {
+	if len(altName) > 0 && altName[0] != "" {
+		return fmt.Sprintf("%s-cluster", altName[0])
+	}
 	return fmt.Sprintf("%s-cluster", cpName)
 }
 
-func GenerateAuthInfoAdminName(cpName string) string {
+func GenerateAuthInfoAdminName(cpName string, altName ...string) string {
+	if len(altName) > 0 && altName[0] != "" {
+		return fmt.Sprintf("%s-admin", altName[0])
+	}
 	return fmt.Sprintf("%s-admin", cpName)
 }
 
-func GenerateContextName(cpName string) string {
+func GenerateContextName(cpName string, altName ...string) string {
+	if len(altName) > 0 && altName[0] != "" {
+		return altName[0]
+	}
 	return cpName
 }
 

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -49,7 +49,7 @@ func LoadAndMerge(ctx context.Context, client kubernetes.Clientset, name, contro
 		}
 		adjustConfigKeys(cpKonfig, name, controlPlaneType)
 
-		err = merge(konfig, cpKonfig)
+		err = merge(konfig, cpKonfig, name)
 		if err != nil {
 			return err
 		}
@@ -71,7 +71,7 @@ func LoadAndMergeNoWrite(ctx context.Context, client kubernetes.Clientset, name,
 	}
 	adjustConfigKeys(cpKonfig, name, controlPlaneType)
 
-	err = merge(konfig, cpKonfig)
+	err = merge(konfig, cpKonfig, name)
 	if err != nil {
 		return err
 	}
@@ -221,9 +221,9 @@ func renameKey(m interface{}, oldKey string, newKey string) interface{} {
 }
 
 func GetCurrentContext(ctx context.Context) (string, error) {
-    kconf, err := LoadKubeconfig(ctx)
-    if err != nil {
-        return "", fmt.Errorf("error loading kubeconfig: %v", err)
-    }
-    return kconf.CurrentContext, nil
+	kconf, err := LoadKubeconfig(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error loading kubeconfig: %v", err)
+	}
+	return kconf.CurrentContext, nil
 }


### PR DESCRIPTION
## Summary

This PR adds support for custom naming in kubeconfig entries. Users can now specify a custom name prefix for the cluster, user, and context entries using the `--custom-name` flag in the `kflex ctx` command.

## Related issue

Fixes #307