### PR TITLE
✨ feature: Move openshift-crds container image to quay.io/kubestellar registry

### DIFF
--- a/config/samples/postcreate-hooks/openshift-crds.yaml
+++ b/config/samples/postcreate-hooks/openshift-crds.yaml
@@ -20,7 +20,7 @@ spec:
               - upgrade
               - --install
               - "{{.HookName}}"
-              - oci://quay.io/pdettori/openshift-crds
+              - oci://quay.io/kubestellar/openshift-crds
               - --version
               - "0.1.0"
             env:


### PR DESCRIPTION
## Summary

This PR updates the container image reference in `openshift-crds.yaml` to use the organization registry (`quay.io/kubestellar`) instead of the personal account (`quay.io/pdettori`).

Changes made:
- Updated image path from `oci://quay.io/pdettori/openshift-crds` to `oci://quay.io/kubestellar/openshift-crds`

## Related issue(s)

Fixes #216