### PR TITLE
✨ feature: Add kflex command to list available contexts

### DIFF
--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -58,6 +58,9 @@ func (c *CPCtx) Context(chattyStatus, failIfNone, overwriteExistingCtx, setCurre
 		}
 		fmt.Println(currentContext)
 		return
+	case "list":
+		c.ListContexts()
+		return
 	case "":
 		if setCurrentCtxAsHosting { // set hosting cluster context unconditionally to the current context
 			kubeconfig.SetHostingClusterContextPreference(kconf, nil)
@@ -190,10 +193,33 @@ func (c *CPCtx) isCurrentContextHostingClusterContext() bool {
 }
 
 func (c *CPCtx) GetCurrentContext() {
-    currentContext, err := kubeconfig.GetCurrentContext(c.Ctx)
-    if err != nil {
-        fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)
-        os.Exit(1)
-    }
-    fmt.Println(currentContext)
+	currentContext, err := kubeconfig.GetCurrentContext(c.Ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(currentContext)
+}
+
+func (c *CPCtx) ListContexts() {
+	kconf, err := kubeconfig.LoadKubeconfig(c.Ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading kubeconfig: %s\n", err)
+		os.Exit(1)
+	}
+
+	if len(kconf.Contexts) == 0 {
+		fmt.Println("No contexts found in kubeconfig")
+		return
+	}
+
+	currentContext := kconf.CurrentContext
+	fmt.Println("Available Contexts:")
+	for name := range kconf.Contexts {
+		prefix := " "
+		if name == currentContext {
+			prefix = "*"
+		}
+		fmt.Printf("%s %s\n", prefix, name)
+	}
 }

--- a/cmd/kflex/ctx/list.go
+++ b/cmd/kflex/ctx/list.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ctx
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type CPContextList struct {
+	CP common.CP
+}
+
+func (cp *CPContextList) ListContexts() {
+	config, err := clientcmd.LoadFromFile(cp.CP.Kubeconfig)
+	if err != nil {
+		fmt.Printf("Error loading kubeconfig: %s\n", err)
+		os.Exit(1)
+	}
+
+	if len(config.Contexts) == 0 {
+		fmt.Println("No contexts found.")
+		return
+	}
+
+	currentContext := config.CurrentContext
+	fmt.Println("Available Contexts:")
+	for name := range config.Contexts {
+		prefix := " "
+		if name == currentContext {
+			prefix = "*"
+		}
+		fmt.Printf("%s %s\n", prefix, name)
+	}
+}

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -32,8 +32,8 @@ import (
 	cont "github.com/kubestellar/kubeflex/cmd/kflex/ctx"
 	del "github.com/kubestellar/kubeflex/cmd/kflex/delete"
 	in "github.com/kubestellar/kubeflex/cmd/kflex/init"
-	"github.com/kubestellar/kubeflex/cmd/kflex/list"
 	cluster "github.com/kubestellar/kubeflex/cmd/kflex/init/cluster"
+	"github.com/kubestellar/kubeflex/cmd/kflex/list"
 	"github.com/kubestellar/kubeflex/pkg/client"
 	"github.com/kubestellar/kubeflex/pkg/util"
 	"github.com/spf13/cobra"
@@ -240,6 +240,22 @@ var listCmd = &cobra.Command{
 	},
 }
 
+var listCtxCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all available contexts",
+	Long:  `List all available contexts in the kubeconfig file`,
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		cp := cont.CPCtx{
+			CP: common.CP{
+				Ctx:        createContext(),
+				Kubeconfig: kubeconfig,
+			},
+		}
+		cp.ListContexts()
+	},
+}
+
 func init() {
 	versionCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to the kubeconfig file for the KubeFlex hosting cluster. If not specified, and $KUBECONFIG is set, it uses the value in $KUBECONFIG, otherwise it falls back to ${HOME}/.kube/configg")
 	versionCmd.Flags().BoolVarP(&chattyStatus, "chatty-status", "s", true, "chatty status indicator")
@@ -281,6 +297,7 @@ func init() {
 	ctxCmd.Flags().BoolVarP(&setCurrentCtxAsHosting, "set-current-for-hosting", "c", false, "Set current context as hosting cluster context")
 
 	ctxCmd.AddCommand(ctxGetCmd)
+	ctxCmd.AddCommand(listCtxCmd)
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)

--- a/docs/users.md
+++ b/docs/users.md
@@ -908,3 +908,10 @@ helm delete -n kubeflex-system postgres
 kubectl delete pvc data-postgres-postgresql-0
 kubectl delete ns kubeflex-system
 ```
+
+## Listing Available Contexts
+
+To list all available contexts in your kubeconfig file, use the following command:
+
+```shell
+kflex ctx list

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -221,9 +221,22 @@ func renameKey(m interface{}, oldKey string, newKey string) interface{} {
 }
 
 func GetCurrentContext(ctx context.Context) (string, error) {
-    kconf, err := LoadKubeconfig(ctx)
-    if err != nil {
-        return "", fmt.Errorf("error loading kubeconfig: %v", err)
-    }
-    return kconf.CurrentContext, nil
+	config, err := LoadKubeconfig(ctx)
+	if err != nil {
+		return "", err
+	}
+	return config.CurrentContext, nil
+}
+
+func ListContexts(ctx context.Context) ([]string, error) {
+	config, err := LoadKubeconfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	contexts := make([]string, 0, len(config.Contexts))
+	for name := range config.Contexts {
+		contexts = append(contexts, name)
+	}
+	return contexts, nil
 }


### PR DESCRIPTION
## Summary

This PR implements the `kflex ctx list` command to display all available contexts in the kubeconfig file, with the current context marked with an asterisk (*). The changes include:

1. Added new `ListContexts()` function in `pkg/kubeconfig/config-util.go`
2. Added new `GetCurrentContext()` helper function
3. Updated `cmd/kflex/ctx/ctx.go` to handle the list command
4. Added new command definition in `cmd/kflex/main.go`
5. Updated documentation in `docs/users.md`

The implementation follows existing patterns in the codebase and provides a clean, user-friendly way to view all available contexts.

## Related issue(s)

Fixes #166