### PR TITLE
✨ Feature: fix brew name to kflex

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,4 +67,16 @@ brews:
     commit_author:
       name: "{{ .Env.USER }}"
       email: "{{ .Env.EMAIL }}"  
+  - name: kflex
+    homepage: "https://github.com/kubestellar/kubeflex"
+    repository:
+      owner: kubestellar
+      name: kubeflex
+      branch: brew
+      pull_request:
+        enabled: false
+    commit_author:
+      name: "{{ .Env.USER }}"
+      email: "{{ .Env.EMAIL }}"  
+
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,17 +56,6 @@ release:
   prerelease: auto
   mode: keep-existing
 brews:
-  - name: kubeflex
-    homepage: "https://github.com/kubestellar/kubeflex"
-    repository:
-      owner: kubestellar
-      name: kubeflex
-      branch: brew
-      pull_request:
-        enabled: false
-    commit_author:
-      name: "{{ .Env.USER }}"
-      email: "{{ .Env.EMAIL }}"  
   - name: kflex
     homepage: "https://github.com/kubestellar/kubeflex"
     repository:

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -58,6 +58,9 @@ func (c *CPCtx) Context(chattyStatus, failIfNone, overwriteExistingCtx, setCurre
 		}
 		fmt.Println(currentContext)
 		return
+	case "list":
+		c.ListContexts()
+		return
 	case "":
 		if setCurrentCtxAsHosting { // set hosting cluster context unconditionally to the current context
 			kubeconfig.SetHostingClusterContextPreference(kconf, nil)
@@ -190,10 +193,22 @@ func (c *CPCtx) isCurrentContextHostingClusterContext() bool {
 }
 
 func (c *CPCtx) GetCurrentContext() {
-    currentContext, err := kubeconfig.GetCurrentContext(c.Ctx)
-    if err != nil {
-        fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)
-        os.Exit(1)
-    }
-    fmt.Println(currentContext)
+	currentContext, err := kubeconfig.GetCurrentContext(c.Ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(currentContext)
+}
+
+func (c *CPCtx) ListContexts() {
+	kconf, err := kubeconfig.LoadKubeconfig(c.Ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading kubeconfig: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Available contexts:")
+	for ctxName := range kconf.Contexts {
+		fmt.Printf("  %s\n", ctxName)
+	}
 }

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -32,8 +32,8 @@ import (
 	cont "github.com/kubestellar/kubeflex/cmd/kflex/ctx"
 	del "github.com/kubestellar/kubeflex/cmd/kflex/delete"
 	in "github.com/kubestellar/kubeflex/cmd/kflex/init"
-	"github.com/kubestellar/kubeflex/cmd/kflex/list"
 	cluster "github.com/kubestellar/kubeflex/cmd/kflex/init/cluster"
+	"github.com/kubestellar/kubeflex/cmd/kflex/list"
 	"github.com/kubestellar/kubeflex/pkg/client"
 	"github.com/kubestellar/kubeflex/pkg/util"
 	"github.com/spf13/cobra"
@@ -240,6 +240,21 @@ var listCmd = &cobra.Command{
 	},
 }
 
+var listCtxCmd = &cobra.Command{
+	Use:   "list-ctx",
+	Short: "List all available kubeconfig contexts",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Construct your CPCtx or retrieve it from global options
+		cpCtx := cont.CPCtx{
+			CP: common.CP{
+				Ctx:        createContext(),
+				Kubeconfig: kubeconfig,
+			},
+		}
+		cpCtx.ListContexts()
+	},
+}
+
 func init() {
 	versionCmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "path to the kubeconfig file for the KubeFlex hosting cluster. If not specified, and $KUBECONFIG is set, it uses the value in $KUBECONFIG, otherwise it falls back to ${HOME}/.kube/configg")
 	versionCmd.Flags().BoolVarP(&chattyStatus, "chatty-status", "s", true, "chatty status indicator")
@@ -289,6 +304,7 @@ func init() {
 	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(ctxCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(listCtxCmd)
 }
 
 // TODO - work on passing the verbosity to the logger


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
In this Pull Request, I am changing the name of kubeflex install of homebrew to kflex.
The changes included:
- Fixing kubeflex to kflex in .gorealeaser.yaml

## Related issue(s)

Fixes #271 
