### PR TITLE
🐛bug fix: Update contributors.md with instructions to fetch upstream tags

### DIFF
--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -13,14 +13,27 @@ Make sure that `${HOME}/go/bin` is in your `$PATH`.
 
 ## How to build kubeflex from source
 
-Clone the repo, build the binaries and add them to your path:
+Clone the repo, set up upstream remote, fetch tags, build the binaries and add them to your path:
 
 ```shell
-git clone https://github.com/kubestellar/kubeflex.git
+# Clone your fork
+git clone https://github.com/<your-username>/kubeflex.git
 cd kubeflex
+
+# Add the upstream repository as a remote
+git remote add upstream https://github.com/kubestellar/kubeflex.git
+
+# Fetch all tags from upstream
+git fetch upstream --tags
+
+# Build the binaries
 make build-all
+
+# Add binaries to your path
 export PATH=$(pwd)/bin:$PATH
 ```
+
+> **Note:** Fetching tags from upstream is important as the version information for KubeFlex binaries is derived from git tags. Without the tags, commands like `kflex init -c` (which initializes KubeFlex and creates a kind cluster) will not work correctly.
 
 ## Setting Up a Testing Cluster for KubeFlex
 

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -16,11 +16,11 @@ Make sure that `${HOME}/go/bin` is in your `$PATH`.
 Clone the repo, set up upstream remote, fetch tags, build the binaries and add them to your path:
 
 ```shell
-# Clone your fork
+# Clone your fork – command only shown for HTTPS; adjust the URL if you prefer SSH
 git clone https://github.com/<your-username>/kubeflex.git
 cd kubeflex
 
-# Add the upstream repository as a remote
+# Add the upstream repository as a remote (adjust the URL if you prefer SSH)
 git remote add upstream https://github.com/kubestellar/kubeflex.git
 
 # Fetch all tags from upstream


### PR DESCRIPTION
## Summary
This PR updates the `contributors.md` file to include instructions for fetching tags from the upstream repository. As mentioned in issue #348, without these tags, commands like `kflex init -c` fail because version information is derived from git tags.

The changes:
- Added instructions to set up the upstream remote
- Added instructions to fetch tags from upstream
- Added a note explaining why fetching tags is important

These simple additions should help new contributors avoid the frustration of commands not working after following the guide.

## Related issue(s)
Fixes #348