### PR TITLE
🐛 bug fix: Retry when PostCreateHook is not found

### DIFF
--- a/pkg/reconcilers/external/reconciler.go
+++ b/pkg/reconcilers/external/reconciler.go
@@ -18,6 +18,7 @@ package external
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -63,6 +64,11 @@ func (r *ExternalReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1
 	if hcp.Spec.PostCreateHook != nil &&
 		tenancyv1alpha1.HasConditionAvailable(hcp.Status.Conditions) {
 		if err := r.ReconcileUpdatePostCreateHook(ctx, hcp); err != nil {
+			// Check if this is a PostCreateHookNotFoundError
+			if _, ok := err.(*shared.PostCreateHookNotFoundError); ok {
+				// Requeue with a delay to wait for the hook to be created
+				return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+			}
 			return r.UpdateStatusForSyncingError(hcp, err)
 		}
 	}

--- a/pkg/reconcilers/host/reconciler.go
+++ b/pkg/reconcilers/host/reconciler.go
@@ -19,6 +19,7 @@ package host
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -78,6 +79,11 @@ func (r *HostReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.Con
 	if hcp.Spec.PostCreateHook != nil &&
 		tenancyv1alpha1.HasConditionAvailable(hcp.Status.Conditions) {
 		if err := r.ReconcileUpdatePostCreateHook(ctx, hcp); err != nil {
+			// Check if this is a PostCreateHookNotFoundError
+			if _, ok := err.(*shared.PostCreateHookNotFoundError); ok {
+				// Requeue with a delay to wait for the hook to be created
+				return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+			}
 			return r.UpdateStatusForSyncingError(hcp, err)
 		}
 	}

--- a/pkg/reconcilers/k8s/reconciler.go
+++ b/pkg/reconcilers/k8s/reconciler.go
@@ -123,6 +123,11 @@ func (r *K8sReconciler) Reconcile(ctx context.Context, hcp *v1alpha1.ControlPlan
 	if hcp.Spec.PostCreateHook != nil &&
 		v1alpha1.HasConditionAvailable(hcp.Status.Conditions) {
 		if err := r.ReconcileUpdatePostCreateHook(ctx, hcp); err != nil {
+			// Check if this is a PostCreateHookNotFoundError
+			if _, ok := err.(*shared.PostCreateHookNotFoundError); ok {
+				// Requeue with a delay to wait for the hook to be created
+				return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+			}
 			return r.UpdateStatusForSyncingError(hcp, err)
 		}
 	}

--- a/pkg/reconcilers/ocm/reconciler.go
+++ b/pkg/reconcilers/ocm/reconciler.go
@@ -114,6 +114,11 @@ func (r *OCMReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.Cont
 	if hcp.Spec.PostCreateHook != nil &&
 		tenancyv1alpha1.HasConditionAvailable(hcp.Status.Conditions) {
 		if err := r.ReconcileUpdatePostCreateHook(ctx, hcp); err != nil {
+			// Check if this is a PostCreateHookNotFoundError
+			if _, ok := err.(*shared.PostCreateHookNotFoundError); ok {
+				// Requeue with a delay to wait for the hook to be created
+				return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+			}
 			return r.UpdateStatusForSyncingError(hcp, err)
 		}
 	}

--- a/pkg/reconcilers/vcluster/reconciler.go
+++ b/pkg/reconcilers/vcluster/reconciler.go
@@ -121,6 +121,11 @@ func (r *VClusterReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1
 	if hcp.Spec.PostCreateHook != nil &&
 		tenancyv1alpha1.HasConditionAvailable(hcp.Status.Conditions) {
 		if err := r.ReconcileUpdatePostCreateHook(ctx, hcp); err != nil {
+			// Check if this is a PostCreateHookNotFoundError
+			if _, ok := err.(*shared.PostCreateHookNotFoundError); ok {
+				// Requeue with a delay to wait for the hook to be created
+				return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+			}
 			return r.UpdateStatusForSyncingError(hcp, err)
 		}
 	}


### PR DESCRIPTION
## Summary
This PR fixes a bug where creating a control plane would fail if the PostCreateHook doesn't exist yet. 

Changes made:
1. Added a special error type to detect when a hook is missing
2. Modified all reconcilers to check for this error type
3. Added logic to retry after 10 seconds when a hook is not found
4. Keeps the control plane in Available state while waiting for the hook

This allows users to create control planes that reference hooks before creating the hooks themselves.

## Related issue(s)
Fixes #319