### PR TITLE
🐛 refactoring and design change on the usage of spf13/cobra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ GIT_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 MAIN_VERSION := $(shell git tag -l --sort=-v:refname | head -n1)
 LDFLAGS := \
-	-X cmd/kflex/common.Version=${MAIN_VERSION}.${GIT_COMMIT} \
-	-X cmd/kflex/common.BuildDate=${BUILD_DATE} \
+	-X github.com/kubestellar/kubeflex/cmd/kflex/common.Version=${MAIN_VERSION}.${GIT_COMMIT} \
+	-X github.com/kubestellar/kubeflex/cmd/kflex/common.BuildDate=${BUILD_DATE} \
 	-X k8s.io/client-go/pkg/version.gitCommit=${GIT_COMMIT} \
 	-X k8s.io/client-go/pkg/version.gitTreeState=${GIT_DIRTY} \
 	-X k8s.io/client-go/pkg/version.gitVersion=${GIT_VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ MAIN_VERSION := $(shell git tag -l --sort=-v:refname | head -n1)
 LDFLAGS := \
 	-X main.Version=${MAIN_VERSION}.${GIT_COMMIT} \
 	-X main.BuildDate=${BUILD_DATE} \
+	-X github.com/kubestellar/kubeflex/cmd/kflex/common.Version= ${MAIN_VERSION}.${GIT_COMMIT} \
+	-X github.com/kubestellar/kubeflex/cmd/kflex/common.BuildDate= ${BUILD_DATE} \
 	-X k8s.io/client-go/pkg/version.gitCommit=${GIT_COMMIT} \
 	-X k8s.io/client-go/pkg/version.gitTreeState=${GIT_DIRTY} \
 	-X k8s.io/client-go/pkg/version.gitVersion=${GIT_VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,8 @@ GIT_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 MAIN_VERSION := $(shell git tag -l --sort=-v:refname | head -n1)
 LDFLAGS := \
-	-X main.Version=${MAIN_VERSION}.${GIT_COMMIT} \
-	-X main.BuildDate=${BUILD_DATE} \
-	-X github.com/kubestellar/kubeflex/cmd/kflex/common.Version= ${MAIN_VERSION}.${GIT_COMMIT} \
-	-X github.com/kubestellar/kubeflex/cmd/kflex/common.BuildDate= ${BUILD_DATE} \
+	-X cmd/kflex/common.Version=${MAIN_VERSION}.${GIT_COMMIT} \
+	-X cmd/kflex/common.BuildDate=${BUILD_DATE} \
 	-X k8s.io/client-go/pkg/version.gitCommit=${GIT_COMMIT} \
 	-X k8s.io/client-go/pkg/version.gitTreeState=${GIT_DIRTY} \
 	-X k8s.io/client-go/pkg/version.gitVersion=${GIT_VERSION} \

--- a/cmd/kflex/adopt/adopt.go
+++ b/cmd/kflex/adopt/adopt.go
@@ -84,7 +84,7 @@ func Command() *cobra.Command {
 				AdoptedURLOverride:            adoptedURLOverride,
 				AdoptedTokenExpirationSeconds: adoptedTokenExpirationSeconds,
 			}
-			execute(cp, postCreateHook, hookVars, chattyStatus)
+			ExecuteAdopt(cp, postCreateHook, hookVars, chattyStatus)
 		},
 	}
 	flagset := command.Flags()
@@ -99,11 +99,11 @@ func Command() *cobra.Command {
 }
 
 // Adopt a control plane from another cluster
-func execute(cp CPAdopt, hook string, hookVars []string, chattyStatus bool) {
+func ExecuteAdopt(cp CPAdopt, hook string, hookVars []string, chattyStatus bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 	cx := cont.CPCtx{}
-	cx.Context(chattyStatus, false, false, false)
+	cx.ExecuteCtx(chattyStatus, false, false, false)
 
 	controlPlaneType := tenancyv1alpha1.ControlPlaneTypeExternal
 	util.PrintStatus(fmt.Sprintf("Adopting control plane %s of type %s ...", cp.Name, controlPlaneType), done, &wg, chattyStatus)

--- a/cmd/kflex/common/cp.go
+++ b/cmd/kflex/common/cp.go
@@ -31,6 +31,7 @@ type CP struct {
 	Ctx        context.Context
 	Kubeconfig string
 	Name       string
+	AliasName string
 }
 
 func GenerateControlPlane(name, controlPlaneType, backendType, hook string, hookVars []string, tokenExpirationSeconds *int64) (*tenancyv1alpha1.ControlPlane, error) {

--- a/cmd/kflex/common/cp.go
+++ b/cmd/kflex/common/cp.go
@@ -21,8 +21,11 @@ import (
 	"fmt"
 	"strings"
 
+	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/pkg/util"
 )
@@ -31,11 +34,44 @@ type CP struct {
 	Ctx        context.Context
 	Kubeconfig string
 	Name       string
-	AliasName string
+	AliasName  string
 }
 
+type CPOption func(*CP)
+
+// New control plane with option design pattern
+func NewCP(kubeconfigPath string, options ...CPOption) CP {
+	cp := CP{Ctx: createContext(), Kubeconfig: kubeconfigPath}
+	for _, option := range options {
+		option(&cp)
+	}
+	return cp
+}
+
+// Make Name optional using option design pattern
+func WithName(name string) CPOption {
+	return func(cp *CP) {
+		cp.Name = name
+	}
+}
+
+// Make AliasName optional using option design pattern
+func WithAliasName(aliasName string) CPOption {
+	return func(cp *CP) {
+		cp.AliasName = aliasName
+	}
+}
+
+// Create a new system context with logger
+func createContext() context.Context {
+	zapLogger, _ := zap.NewDevelopment(zap.AddCaller())
+	logger := zapr.NewLoggerWithOptions(zapLogger)
+	return logr.NewContext(context.Background(), logger)
+}
+
+// REFACTOR: the usage of the variable `cp` as *common.CP and then overshadowed by `cp` as tenancyv1alpha1.ControlPlane was tricky. Took a while to understand. Hence, `cp` from tenancyv1alpha1 becomes `controlPlane` and common.CP is referred by `cp`
 func GenerateControlPlane(name, controlPlaneType, backendType, hook string, hookVars []string, tokenExpirationSeconds *int64) (*tenancyv1alpha1.ControlPlane, error) {
-	cp := &tenancyv1alpha1.ControlPlane{
+	controlPlane := &tenancyv1alpha1.ControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -46,21 +82,21 @@ func GenerateControlPlane(name, controlPlaneType, backendType, hook string, hook
 		},
 	}
 	if hook != "" {
-		cp.Spec.PostCreateHook = &hook
+		controlPlane.Spec.PostCreateHook = &hook
 		var err error
-		cp.Spec.PostCreateHookVars, err = convertToMap(hookVars)
+		controlPlane.Spec.PostCreateHookVars, err = convertToMap(hookVars)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if controlPlaneType == string(tenancyv1alpha1.ControlPlaneTypeExternal) {
-		cp.Spec.BootstrapSecretRef = &tenancyv1alpha1.BootstrapSecretReference{
+		controlPlane.Spec.BootstrapSecretRef = &tenancyv1alpha1.BootstrapSecretReference{
 			Name:         util.GenerateBootstrapSecretName(name),
 			Namespace:    util.SystemNamespace,
 			InClusterKey: util.KubeconfigSecretKeyInCluster,
 		}
 	}
-	return cp, nil
+	return controlPlane, nil
 }
 
 func convertToMap(pairs []string) (map[string]string, error) {

--- a/cmd/kflex/common/cp.go
+++ b/cmd/kflex/common/cp.go
@@ -69,7 +69,7 @@ func createContext() context.Context {
 	return logr.NewContext(context.Background(), logger)
 }
 
-// REFACTOR: the usage of the variable `cp` as *common.CP and then overshadowed by `cp` as tenancyv1alpha1.ControlPlane was tricky. Took a while to understand. Hence, `cp` from tenancyv1alpha1 becomes `controlPlane` and common.CP is referred by `cp`
+// Generate a control plane based with a name
 func GenerateControlPlane(name, controlPlaneType, backendType, hook string, hookVars []string, tokenExpirationSeconds *int64) (*tenancyv1alpha1.ControlPlane, error) {
 	controlPlane := &tenancyv1alpha1.ControlPlane{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/kflex/common/flags.go
+++ b/cmd/kflex/common/flags.go
@@ -19,8 +19,9 @@ package common
 import "k8s.io/client-go/tools/clientcmd"
 
 const (
-	KubeconfigFlag   = clientcmd.RecommendedConfigPathFlag
-	ChattyStatusFlag = "chatty-status"
-	VerbosityFlag    = "verbosity"
-	SetFlag          = "set"
+	KubeconfigFlag     = clientcmd.RecommendedConfigPathFlag
+	ChattyStatusFlag   = "chatty-status"
+	VerbosityFlag      = "verbosity"
+	PostCreateHookFlag = "postcreate-hook"
+	SetFlag            = "set"
 )

--- a/cmd/kflex/common/flags.go
+++ b/cmd/kflex/common/flags.go
@@ -25,3 +25,9 @@ const (
 	PostCreateHookFlag = "postcreate-hook"
 	SetFlag            = "set"
 )
+
+// Version injected by makefile:LDFLAGS
+var Version string
+
+// BuildDate injected by makefile:LDFLAGS
+var BuildDate string

--- a/cmd/kflex/common/flags.go
+++ b/cmd/kflex/common/flags.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import "k8s.io/client-go/tools/clientcmd"
+
+const (
+	KubeconfigFlag   = clientcmd.RecommendedConfigPathFlag
+	ChattyStatusFlag = "chatty-status"
+	VerbosityFlag    = "verbosity"
+	SetFlag          = "set"
+)

--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
@@ -32,37 +33,77 @@ import (
 	"github.com/kubestellar/kubeflex/pkg/util"
 )
 
-type CPCreate struct {
-	common.CP
+// defaults
+const (
+	BKTypeDefault        = string(tenancyv1alpha1.BackendDBTypeShared) // REFACTOR? local to create or common
+	CTypeDefault         = string(tenancyv1alpha1.ControlPlaneTypeK8S) // REFACTOR? local to create or common
+	ControlPlaneTypeFlag = "type"
+	BackendTypeFlag      = "backend-type"
+	PostCreateHookFlag   = "postcreate-hook"
+	ChattyStatusFlag     = "chatty-status"
+)
+
+// REFACTOR: removed variables such as `hookVars` as they are used by multiple commands (create and adopt...). It should be defined locally to each command package instead of pointing to the same variable defined in main avoiding extreme edge cases.
+
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a control plane instance",
+		Long: `Create a control plane instance and switches the Kubeconfig context to
+	        the current instance`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			flagset := cmd.Flags()
+			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
+			chattyStatus, _ := flagset.GetBool(common.ChattyStatusFlag)
+			cpType, _ := flagset.GetString(ControlPlaneTypeFlag)
+			backendType, _ := flagset.GetString(BackendTypeFlag)
+			postCreateHook, _ := flagset.GetString(PostCreateHookFlag)
+			hookVars, _ := flagset.GetStringArray(common.SetFlag)
+			cp := common.NewCP(kubeconfig, common.WithName(args[0]))
+			// create passing the control plane type and backend type
+			execute(cp, cpType, backendType, postCreateHook, hookVars, chattyStatus)
+		},
+	}
+
+	flagset := command.Flags()
+	// REFACTOR: putting CTypeDefault as default value, hence if empty string given to the flag, it picks up
+	flagset.StringP(ControlPlaneTypeFlag, "t", CTypeDefault, "type of control plane: k8s|ocm|vcluster")
+	// REFACTOR: same than CTypeDefault for BKTypeDefault
+	flagset.StringP(BackendTypeFlag, "b", BKTypeDefault, "backend DB sharing: shared|dedicated")
+	flagset.StringP(PostCreateHookFlag, "p", "", "name of post create hook to run")
+	flagset.BoolP(ChattyStatusFlag, "s", true, "chatty status indicator")
+	flagset.StringArrayP(common.SetFlag, "e", []string{}, "set post create hook variables, in the form name=value ")
+	return command
 }
 
 // Create a new control plane
-func (c *CPCreate) Create(controlPlaneType, backendType, hook string, hookVars []string, chattyStatus bool) {
+func execute(cp common.CP, controlPlaneType string, backendType string, hook string, hookVars []string, chattyStatus bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 	cx := cont.CPCtx{}
 	cx.Context(chattyStatus, false, false, false)
 
-	cl, err := kfclient.GetClient(c.Kubeconfig)
+	cl, err := kfclient.GetClient(cp.Kubeconfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error getting client: %v\n", err)
 		os.Exit(1)
 	}
 
-	cp, err := common.GenerateControlPlane(c.Name, controlPlaneType, backendType, hook, hookVars, nil)
+	controlPlane, err := common.GenerateControlPlane(cp.Name, controlPlaneType, backendType, hook, hookVars, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error generating control plane object: %v\n", err)
 		os.Exit(1)
 	}
 
-	util.PrintStatus(fmt.Sprintf("Creating new control plane %s of type %s ...", c.Name, controlPlaneType), done, &wg, chattyStatus)
-	if err := cl.Create(context.TODO(), cp, &client.CreateOptions{}); err != nil {
+	util.PrintStatus(fmt.Sprintf("Creating new control plane %s of type %s ...", cp.Name, controlPlaneType), done, &wg, chattyStatus)
+	if err := cl.Create(context.TODO(), controlPlane, &client.CreateOptions{}); err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating instance: %v\n", err)
 		os.Exit(1)
 	}
 	done <- true
 
-	clientsetp, err := kfclient.GetClientSet(c.Kubeconfig)
+	clientsetp, err := kfclient.GetClientSet(cp.Kubeconfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error getting clientset: %v\n", err)
 		os.Exit(1)
@@ -70,7 +111,7 @@ func (c *CPCreate) Create(controlPlaneType, backendType, hook string, hookVars [
 	clientset := *clientsetp
 
 	util.PrintStatus("Waiting for API server to become ready...", done, &wg, chattyStatus)
-	kubeconfig.WatchForSecretCreation(clientset, c.Name, util.GetKubeconfSecretNameByControlPlaneType(controlPlaneType))
+	kubeconfig.WatchForSecretCreation(clientset, cp.Name, util.GetKubeconfSecretNameByControlPlaneType(controlPlaneType))
 
 	switch controlPlaneType {
 	case string(tenancyv1alpha1.ControlPlaneTypeHost):
@@ -78,7 +119,7 @@ func (c *CPCreate) Create(controlPlaneType, backendType, hook string, hookVars [
 	case string(tenancyv1alpha1.ControlPlaneTypeVCluster):
 		if err := util.WaitForStatefulSetReady(clientset,
 			util.GetAPIServerDeploymentNameByControlPlaneType(controlPlaneType),
-			util.GenerateNamespaceFromControlPlaneName(cp.Name)); err != nil {
+			util.GenerateNamespaceFromControlPlaneName(controlPlane.Name)); err != nil {
 
 			fmt.Fprintf(os.Stderr, "Error waiting for stateful set to become ready: %v\n", err)
 			os.Exit(1)
@@ -86,7 +127,7 @@ func (c *CPCreate) Create(controlPlaneType, backendType, hook string, hookVars [
 	case string(tenancyv1alpha1.ControlPlaneTypeK8S), string(tenancyv1alpha1.ControlPlaneTypeOCM):
 		if err := util.WaitForDeploymentReady(clientset,
 			util.GetAPIServerDeploymentNameByControlPlaneType(controlPlaneType),
-			util.GenerateNamespaceFromControlPlaneName(cp.Name)); err != nil {
+			util.GenerateNamespaceFromControlPlaneName(controlPlane.Name)); err != nil {
 
 			fmt.Fprintf(os.Stderr, "Error waiting for deployment to become ready: %v\n", err)
 			os.Exit(1)
@@ -98,7 +139,7 @@ func (c *CPCreate) Create(controlPlaneType, backendType, hook string, hookVars [
 
 	done <- true
 
-	if err := kubeconfig.LoadAndMerge(c.Ctx, clientset, c.Name, controlPlaneType); err != nil {
+	if err := kubeconfig.LoadAndMerge(cp.Ctx, clientset, cp.Name, controlPlaneType); err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading and merging kubeconfig: %s\n", err)
 		os.Exit(1)
 	}

--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -35,13 +35,11 @@ import (
 
 // defaults
 const (
-	BKTypeDefault        = string(tenancyv1alpha1.BackendDBTypeShared) // REFACTOR? local to create or common
-	CTypeDefault         = string(tenancyv1alpha1.ControlPlaneTypeK8S) // REFACTOR? local to create or common
+	BKTypeDefault        = string(tenancyv1alpha1.BackendDBTypeShared) 
+	CTypeDefault         = string(tenancyv1alpha1.ControlPlaneTypeK8S) 
 	ControlPlaneTypeFlag = "type"
 	BackendTypeFlag      = "backend-type"
 )
-
-// REFACTOR: removed variables such as `hookVars` as they are used by multiple commands (create and adopt...). It should be defined locally to each command package instead of pointing to the same variable defined in main avoiding extreme edge cases.
 
 func Command() *cobra.Command {
 	command := &cobra.Command{
@@ -65,9 +63,7 @@ func Command() *cobra.Command {
 	}
 
 	flagset := command.Flags()
-	// REFACTOR: putting CTypeDefault as default value, hence if empty string given to the flag, it picks up
 	flagset.StringP(ControlPlaneTypeFlag, "t", CTypeDefault, "type of control plane: k8s|ocm|vcluster")
-	// REFACTOR: same than CTypeDefault for BKTypeDefault
 	flagset.StringP(BackendTypeFlag, "b", BKTypeDefault, "backend DB sharing: shared|dedicated")
 	flagset.StringP(common.PostCreateHookFlag, "p", "", "name of post create hook to run")
 	flagset.BoolP(common.ChattyStatusFlag, "s", true, "chatty status indicator")

--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -60,7 +60,7 @@ func Command() *cobra.Command {
 			hookVars, _ := flagset.GetStringArray(common.SetFlag)
 			cp := common.NewCP(kubeconfig, common.WithName(args[0]))
 			// create passing the control plane type and backend type
-			execute(cp, cpType, backendType, postCreateHook, hookVars, chattyStatus)
+			ExecuteCreate(cp, cpType, backendType, postCreateHook, hookVars, chattyStatus)
 		},
 	}
 
@@ -76,11 +76,11 @@ func Command() *cobra.Command {
 }
 
 // Create a new control plane
-func execute(cp common.CP, controlPlaneType string, backendType string, hook string, hookVars []string, chattyStatus bool) {
+func ExecuteCreate(cp common.CP, controlPlaneType string, backendType string, hook string, hookVars []string, chattyStatus bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 	cx := cont.CPCtx{}
-	cx.Context(chattyStatus, false, false, false)
+	cx.ExecuteCtx(chattyStatus, false, false, false)
 
 	cl, err := kfclient.GetClient(cp.Kubeconfig)
 	if err != nil {

--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -39,8 +39,8 @@ const (
 	CTypeDefault         = string(tenancyv1alpha1.ControlPlaneTypeK8S) // REFACTOR? local to create or common
 	ControlPlaneTypeFlag = "type"
 	BackendTypeFlag      = "backend-type"
-	PostCreateHookFlag   = "postcreate-hook"
-	ChattyStatusFlag     = "chatty-status"
+
+	ChattyStatusFlag = "chatty-status"
 )
 
 // REFACTOR: removed variables such as `hookVars` as they are used by multiple commands (create and adopt...). It should be defined locally to each command package instead of pointing to the same variable defined in main avoiding extreme edge cases.
@@ -58,7 +58,7 @@ func Command() *cobra.Command {
 			chattyStatus, _ := flagset.GetBool(common.ChattyStatusFlag)
 			cpType, _ := flagset.GetString(ControlPlaneTypeFlag)
 			backendType, _ := flagset.GetString(BackendTypeFlag)
-			postCreateHook, _ := flagset.GetString(PostCreateHookFlag)
+			postCreateHook, _ := flagset.GetString(common.PostCreateHookFlag)
 			hookVars, _ := flagset.GetStringArray(common.SetFlag)
 			cp := common.NewCP(kubeconfig, common.WithName(args[0]))
 			// create passing the control plane type and backend type
@@ -71,7 +71,7 @@ func Command() *cobra.Command {
 	flagset.StringP(ControlPlaneTypeFlag, "t", CTypeDefault, "type of control plane: k8s|ocm|vcluster")
 	// REFACTOR: same than CTypeDefault for BKTypeDefault
 	flagset.StringP(BackendTypeFlag, "b", BKTypeDefault, "backend DB sharing: shared|dedicated")
-	flagset.StringP(PostCreateHookFlag, "p", "", "name of post create hook to run")
+	flagset.StringP(common.PostCreateHookFlag, "p", "", "name of post create hook to run")
 	flagset.BoolP(ChattyStatusFlag, "s", true, "chatty status indicator")
 	flagset.StringArrayP(common.SetFlag, "e", []string{}, "set post create hook variables, in the form name=value ")
 	return command

--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -39,8 +39,6 @@ const (
 	CTypeDefault         = string(tenancyv1alpha1.ControlPlaneTypeK8S) // REFACTOR? local to create or common
 	ControlPlaneTypeFlag = "type"
 	BackendTypeFlag      = "backend-type"
-
-	ChattyStatusFlag = "chatty-status"
 )
 
 // REFACTOR: removed variables such as `hookVars` as they are used by multiple commands (create and adopt...). It should be defined locally to each command package instead of pointing to the same variable defined in main avoiding extreme edge cases.
@@ -72,7 +70,7 @@ func Command() *cobra.Command {
 	// REFACTOR: same than CTypeDefault for BKTypeDefault
 	flagset.StringP(BackendTypeFlag, "b", BKTypeDefault, "backend DB sharing: shared|dedicated")
 	flagset.StringP(common.PostCreateHookFlag, "p", "", "name of post create hook to run")
-	flagset.BoolP(ChattyStatusFlag, "s", true, "chatty status indicator")
+	flagset.BoolP(common.ChattyStatusFlag, "s", true, "chatty status indicator")
 	flagset.StringArrayP(common.SetFlag, "e", []string{}, "set post create hook variables, in the form name=value ")
 	return command
 }

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -67,7 +67,7 @@ func Command() *cobra.Command {
 			cp := CPCtx{
 				CP: common.NewCP(kubeconfig, common.WithName(cpName), common.WithAliasName(aliasName)),
 			}
-			cp.Context(chattyStatus, true, overwriteExistingCtx, setCurrentCtxAsHosting)
+			cp.ExecuteCtx(chattyStatus, true, overwriteExistingCtx, setCurrentCtxAsHosting)
 		},
 	}
 	flagset := command.Flags()
@@ -80,7 +80,7 @@ func Command() *cobra.Command {
 }
 
 // Context switch context in Kubeconfig
-func (c *CPCtx) Context(chattyStatus, failIfNone, overwriteExistingCtx, setCurrentCtxAsHosting bool) {
+func (c *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, setCurrentCtxAsHosting bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 	kconf, err := kubeconfig.LoadKubeconfig(c.Ctx)
@@ -91,10 +91,10 @@ func (c *CPCtx) Context(chattyStatus, failIfNone, overwriteExistingCtx, setCurre
 
 	switch c.CP.Name {
 	case "get":
-		GetCurrentContext(c.CP)
+		ExecuteCtxGet(c.CP)
 		return
 	case "list":
-		ListContexts(c.CP)
+		ExecuteCtxList(c.CP)
 		return
 	case "":
 		if setCurrentCtxAsHosting { // set hosting cluster context unconditionally to the current context

--- a/cmd/kflex/ctx/get.go
+++ b/cmd/kflex/ctx/get.go
@@ -18,13 +18,13 @@ func CommandGet() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			kubeconfig, _ := cmd.Flags().GetString(common.KubeconfigFlag)
 			cp := common.NewCP(kubeconfig)
-			GetCurrentContext(cp)
+			ExecuteCtxGet(cp)
 		},
 	}
 	return command
 }
 
-func GetCurrentContext(cp common.CP) {
+func ExecuteCtxGet(cp common.CP) {
 	currentContext, err := kubeconfig.GetCurrentContext(cp.Ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)

--- a/cmd/kflex/ctx/get.go
+++ b/cmd/kflex/ctx/get.go
@@ -1,0 +1,34 @@
+package ctx
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+	"github.com/spf13/cobra"
+)
+
+func CommandGet() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "get",
+		Short: "Get the current kubeconfig context",
+		Long:  `Retrieve and display the current context from the kubeconfig file`,
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			kubeconfig, _ := cmd.Flags().GetString(common.KubeconfigFlag)
+			cp := common.NewCP(kubeconfig)
+			GetCurrentContext(cp)
+		},
+	}
+	return command
+}
+
+func GetCurrentContext(cp common.CP) {
+	currentContext, err := kubeconfig.GetCurrentContext(cp.Ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error retrieving current context: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(currentContext)
+}

--- a/cmd/kflex/ctx/list.go
+++ b/cmd/kflex/ctx/list.go
@@ -21,15 +21,26 @@ import (
 	"os"
 
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-type CPContextList struct {
-	CP common.CP
+func CommandList() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all available contexts",
+		Long:  `List all available contexts in the kubeconfig file`,
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			kubeconfig, _ := cmd.Flags().GetString(common.KubeconfigFlag)
+			cp := common.NewCP(kubeconfig)
+			ListContexts(cp)
+		},
+	}
 }
 
-func (cp *CPContextList) ListContexts() {
-	config, err := clientcmd.LoadFromFile(cp.CP.Kubeconfig)
+func ListContexts(cp common.CP) {
+	config, err := clientcmd.LoadFromFile(cp.Kubeconfig)
 	if err != nil {
 		fmt.Printf("Error loading kubeconfig: %s\n", err)
 		os.Exit(1)

--- a/cmd/kflex/ctx/list.go
+++ b/cmd/kflex/ctx/list.go
@@ -34,12 +34,12 @@ func CommandList() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			kubeconfig, _ := cmd.Flags().GetString(common.KubeconfigFlag)
 			cp := common.NewCP(kubeconfig)
-			ListContexts(cp)
+			ExecuteCtxList(cp)
 		},
 	}
 }
 
-func ListContexts(cp common.CP) {
+func ExecuteCtxList(cp common.CP) {
 	config, err := clientcmd.LoadFromFile(cp.Kubeconfig)
 	if err != nil {
 		fmt.Printf("Error loading kubeconfig: %s\n", err)

--- a/cmd/kflex/delete/delete.go
+++ b/cmd/kflex/delete/delete.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,21 +34,34 @@ import (
 	"github.com/kubestellar/kubeflex/pkg/util"
 )
 
-type CPDelete struct {
-	common.CP
+func Command() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a control plane instance",
+		Long: `Delete a control plane instance and switches the context back to
+				the hosting cluster context`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			flagset := cmd.Flags()
+			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
+			chattyStatus, _ := flagset.GetBool(common.ChattyStatusFlag)
+			cp := common.NewCP(kubeconfig, common.WithName(args[0]))
+			execute(cp, chattyStatus)
+		},
+	}
 }
 
-func (c *CPDelete) Delete(chattyStatus bool) {
+func execute(cp common.CP, chattyStatus bool) {
 	done := make(chan bool)
-	cp := &tenancyv1alpha1.ControlPlane{
+	controlPlane := &tenancyv1alpha1.ControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: c.Name,
+			Name: cp.Name,
 		},
 	}
 	var wg sync.WaitGroup
 
-	util.PrintStatus(fmt.Sprintf("Deleting control plane %s...", c.Name), done, &wg, chattyStatus)
-	kconf, err := kubeconfig.LoadKubeconfig(c.Ctx)
+	util.PrintStatus(fmt.Sprintf("Deleting control plane %s...", cp.Name), done, &wg, chattyStatus)
+	kconf, err := kubeconfig.LoadKubeconfig(cp.Ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading kubeconfig: %s\n", err)
 		os.Exit(1)
@@ -58,44 +72,44 @@ func (c *CPDelete) Delete(chattyStatus bool) {
 		os.Exit(1)
 	}
 
-	if err := kubeconfig.WriteKubeconfig(c.Ctx, kconf); err != nil {
+	if err := kubeconfig.WriteKubeconfig(cp.Ctx, kconf); err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing kubeconfig: %s\n", err)
 		os.Exit(1)
 	}
 
-	kfcClient, err := kfclient.GetClient(c.Kubeconfig)
+	kfcClient, err := kfclient.GetClient(cp.Kubeconfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error getting kf client: %s\n", err)
 		os.Exit(1)
 	}
 
-	if err := kfcClient.Get(context.TODO(), client.ObjectKeyFromObject(cp), cp, &client.GetOptions{}); err != nil {
+	if err := kfcClient.Get(context.TODO(), client.ObjectKeyFromObject(controlPlane), controlPlane, &client.GetOptions{}); err != nil {
 		fmt.Fprintf(os.Stderr, "control plane not found on server: %s", err)
 	}
 
-	if err := kfcClient.Delete(context.TODO(), cp, &client.DeleteOptions{}); err != nil {
+	if err := kfcClient.Delete(context.TODO(), controlPlane, &client.DeleteOptions{}); err != nil {
 		fmt.Fprintf(os.Stderr, "Error deleting instance: %s\n", err)
 		os.Exit(1)
 	}
 	done <- true
 
-	clientsetp, err := kfclient.GetClientSet(c.Kubeconfig)
+	clientsetp, err := kfclient.GetClientSet(cp.Kubeconfig)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error getting kf client: %s\n", err)
 		os.Exit(1)
 	}
 	clientset := *clientsetp
-	util.PrintStatus(fmt.Sprintf("Waiting for control plane %s to be deleted...", c.Name), done, &wg, chattyStatus)
-	util.WaitForNamespaceDeletion(clientset, util.GenerateNamespaceFromControlPlaneName(c.Name))
+	util.PrintStatus(fmt.Sprintf("Waiting for control plane %s to be deleted...", cp.Name), done, &wg, chattyStatus)
+	util.WaitForNamespaceDeletion(clientset, util.GenerateNamespaceFromControlPlaneName(cp.Name))
 
-	if cp.Spec.Type != tenancyv1alpha1.ControlPlaneTypeHost &&
-		cp.Spec.Type != tenancyv1alpha1.ControlPlaneTypeExternal {
-		if err := kubeconfig.DeleteContext(kconf, c.Name); err != nil {
-			fmt.Fprintf(os.Stderr, "no kubeconfig context for %s was found: %s\n", c.Name, err)
+	if controlPlane.Spec.Type != tenancyv1alpha1.ControlPlaneTypeHost &&
+		controlPlane.Spec.Type != tenancyv1alpha1.ControlPlaneTypeExternal {
+		if err := kubeconfig.DeleteContext(kconf, cp.Name); err != nil {
+			fmt.Fprintf(os.Stderr, "no kubeconfig context for %s was found: %s\n", cp.Name, err)
 			os.Exit(1)
 		}
 
-		if err := kubeconfig.WriteKubeconfig(c.Ctx, kconf); err != nil {
+		if err := kubeconfig.WriteKubeconfig(cp.Ctx, kconf); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing kubeconfig: %s\n", err)
 			os.Exit(1)
 		}

--- a/cmd/kflex/delete/delete.go
+++ b/cmd/kflex/delete/delete.go
@@ -46,12 +46,12 @@ func Command() *cobra.Command {
 			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
 			chattyStatus, _ := flagset.GetBool(common.ChattyStatusFlag)
 			cp := common.NewCP(kubeconfig, common.WithName(args[0]))
-			execute(cp, chattyStatus)
+			ExecuteDelete(cp, chattyStatus)
 		},
 	}
 }
 
-func execute(cp common.CP, chattyStatus bool) {
+func ExecuteDelete(cp common.CP, chattyStatus bool) {
 	done := make(chan bool)
 	controlPlane := &tenancyv1alpha1.ControlPlane{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/kflex/init/cluster/kind.go
+++ b/cmd/kflex/init/cluster/kind.go
@@ -19,7 +19,7 @@ package cluster
 import (
 	"bytes"
 	"fmt"
-	"log" // REFACTOR: why make use of log when using zap lib
+	"log"
 	"os"
 	"os/exec"
 	"strings"

--- a/cmd/kflex/init/cluster/kind.go
+++ b/cmd/kflex/init/cluster/kind.go
@@ -19,7 +19,7 @@ package cluster
 import (
 	"bytes"
 	"fmt"
-	"log"
+	"log" // REFACTOR: why make use of log when using zap lib
 	"os"
 	"os/exec"
 	"strings"

--- a/cmd/kflex/init/init.go
+++ b/cmd/kflex/init/init.go
@@ -85,7 +85,7 @@ func Command() *cobra.Command {
 
 			// REFACTOR: leverage CP struct to give Context and Kubeconfig
 			cp := common.NewCP(kubeconfig)
-			execute(cp.Ctx, cp.Kubeconfig, common.Version, common.BuildDate, domain, strconv.Itoa(externalPort), hostContainer, chattyStatus, isOCP)
+			ExecuteInit(cp.Ctx, cp.Kubeconfig, common.Version, common.BuildDate, domain, strconv.Itoa(externalPort), hostContainer, chattyStatus, isOCP)
 			wg.Wait()
 		},
 	}
@@ -97,7 +97,7 @@ func Command() *cobra.Command {
 	return command
 }
 
-func execute(ctx context.Context, kubeconfig, version, buildDate string, domain, externalPort, hostContainer string, chattyStatus, isOCP bool) {
+func ExecuteInit(ctx context.Context, kubeconfig, version, buildDate string, domain, externalPort, hostContainer string, chattyStatus, isOCP bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 

--- a/cmd/kflex/init/init.go
+++ b/cmd/kflex/init/init.go
@@ -28,13 +28,76 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/kubestellar/kubeflex/cmd/kflex/init/cluster"
 	"github.com/kubestellar/kubeflex/pkg/client"
 	"github.com/kubestellar/kubeflex/pkg/helm"
 	kcfg "github.com/kubestellar/kubeflex/pkg/kubeconfig"
 	"github.com/kubestellar/kubeflex/pkg/util"
+	"github.com/spf13/cobra"
 )
 
-func Init(ctx context.Context, kubeconfig, version, buildDate string, domain, externalPort, hostContainer string, chattyStatus, isOCP bool) {
+const (
+	CreateKindFlag        = "create-kind"
+	DomainFlag            = "domain"
+	HostContainerNameFlag = "hostContainerName" // REFACTOR? replace with host-container-name?
+	ExternalPortFlag      = "externalPort"      // REFACTOR? replace with external-port?
+)
+
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize kubeflex",
+		Long:  `Installs the default shared storage backend and the kubeflex operator`,
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+
+			flagset := cmd.Flags()
+			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
+			chattyStatus, _ := flagset.GetBool(common.ChattyStatusFlag)
+			createkind, _ := flagset.GetBool(CreateKindFlag)
+			domain, _ := flagset.GetString(DomainFlag)
+			externalPort, _ := flagset.GetInt(ExternalPortFlag)
+			hostContainer, _ := flagset.GetString(HostContainerNameFlag)
+			done := make(chan bool)
+			var wg sync.WaitGroup
+			var isOCP bool
+
+			util.PrintStatus("Checking if OpenShift cluster...", done, &wg, chattyStatus)
+			clientsetp, err := client.GetClientSet(kubeconfig)
+			if err == nil {
+				isOCP = util.IsOpenShift(*clientsetp)
+				if isOCP {
+					done <- true
+					util.PrintStatus("OpenShift cluster detected", done, &wg, chattyStatus)
+				}
+			}
+			done <- true
+
+			if createkind {
+				if isOCP {
+					fmt.Fprintf(os.Stderr, "OpenShift cluster detected on existing context\n")
+					fmt.Fprintf(os.Stdout, "Switch to a non-OpenShift context with `kubectl config use-context <context-name>` and retry.\n")
+					os.Exit(1)
+				}
+				cluster.CreateKindCluster(chattyStatus)
+			}
+
+			// REFACTOR: leverage CP struct to give Context and Kubeconfig
+			cp := common.NewCP(kubeconfig)
+			execute(cp.Ctx, cp.Kubeconfig, common.Version, common.BuildDate, domain, strconv.Itoa(externalPort), hostContainer, chattyStatus, isOCP)
+			wg.Wait()
+		},
+	}
+	flagset := command.Flags()
+	flagset.BoolP(CreateKindFlag, "c", false, "Create and configure a kind cluster for installing Kubeflex")
+	flagset.StringP(DomainFlag, "d", "localtest.me", "domain for FQDN")
+	flagset.StringP(HostContainerNameFlag, "n", "kubeflex-control-plane", "Name of the hosting cluster container (kind or k3d only)")
+	flagset.IntP(ExternalPortFlag, "p", 9443, "external port used by ingress")
+	return command
+}
+
+func execute(ctx context.Context, kubeconfig, version, buildDate string, domain, externalPort, hostContainer string, chattyStatus, isOCP bool) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 

--- a/cmd/kflex/init/init.go
+++ b/cmd/kflex/init/init.go
@@ -40,8 +40,8 @@ import (
 const (
 	CreateKindFlag        = "create-kind"
 	DomainFlag            = "domain"
-	HostContainerNameFlag = "hostContainerName" // REFACTOR? replace with host-container-name?
-	ExternalPortFlag      = "externalPort"      // REFACTOR? replace with external-port?
+	HostContainerNameFlag = "host-container-name" // REFACTOR? replace with host-container-name?
+	ExternalPortFlag      = "external-port"        // REFACTOR? replace with external-port?
 )
 
 func Command() *cobra.Command {
@@ -83,7 +83,6 @@ func Command() *cobra.Command {
 				cluster.CreateKindCluster(chattyStatus)
 			}
 
-			// REFACTOR: leverage CP struct to give Context and Kubeconfig
 			cp := common.NewCP(kubeconfig)
 			ExecuteInit(cp.Ctx, cp.Kubeconfig, common.Version, common.BuildDate, domain, strconv.Itoa(externalPort), hostContainer, chattyStatus, isOCP)
 			wg.Wait()

--- a/cmd/kflex/list/list.go
+++ b/cmd/kflex/list/list.go
@@ -36,9 +36,8 @@ func Command() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			flagset := cmd.Flags()
 			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
-			chattyStatus, _ := flagset.GetBool(common.ChattyStatusFlag)
 			cp := common.NewCP(kubeconfig)
-			ExecuteList(cp, chattyStatus)
+			ExecuteList(cp)
 		},
 	}
 }
@@ -48,9 +47,7 @@ func getAge(creationTime time.Time) string {
 	return duration.Round(time.Second).String()
 }
 
-// REFACTOR: the usage of the variable `cp` as *common.CP and then overshadowed by `cp` as tenancyv1alpha1.ControlPlane was tricky. Took a while to understand. Hence, `cps` and `cp` from tenancyv1alpha1 becomes `controlPlanes` and `controlPlane` and common.CP is referred by `cp`
-// REFACTOR? chattyStatus is unused
-func ExecuteList(cp common.CP, chattyStatus bool) {
+func ExecuteList(cp common.CP) {
 	client, err := client.GetClient(cp.Kubeconfig)
 	if err != nil {
 		fmt.Printf("Error getting client: %s\n", err)
@@ -84,6 +81,6 @@ func ExecuteList(cp common.CP, chattyStatus bool) {
 			}
 		}
 
-		fmt.Printf("%-20s %-10s %-10s %-10s %-10s\n", cp.Name, synced, ready, controlPlane.Spec.Type, age)
+		fmt.Printf("%-20s %-10s %-10s %-10s %-10s\n", controlPlane.Name, synced, ready, controlPlane.Spec.Type, age)
 	}
 }

--- a/cmd/kflex/list/list.go
+++ b/cmd/kflex/list/list.go
@@ -38,7 +38,7 @@ func Command() *cobra.Command {
 			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
 			chattyStatus, _ := flagset.GetBool(common.ChattyStatusFlag)
 			cp := common.NewCP(kubeconfig)
-			execute(cp, chattyStatus)
+			ExecuteList(cp, chattyStatus)
 		},
 	}
 }
@@ -50,7 +50,7 @@ func getAge(creationTime time.Time) string {
 
 // REFACTOR: the usage of the variable `cp` as *common.CP and then overshadowed by `cp` as tenancyv1alpha1.ControlPlane was tricky. Took a while to understand. Hence, `cps` and `cp` from tenancyv1alpha1 becomes `controlPlanes` and `controlPlane` and common.CP is referred by `cp`
 // REFACTOR? chattyStatus is unused
-func execute(cp common.CP, chattyStatus bool) {
+func ExecuteList(cp common.CP, chattyStatus bool) {
 	client, err := client.GetClient(cp.Kubeconfig)
 	if err != nil {
 		fmt.Printf("Error getting client: %s\n", err)

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/kubestellar/kubeflex/cmd/kflex/delete"
 	kflexInit "github.com/kubestellar/kubeflex/cmd/kflex/init"
 	"github.com/kubestellar/kubeflex/cmd/kflex/list"
-	"github.com/kubestellar/kubeflex/pkg/util"
+	"github.com/kubestellar/kubeflex/cmd/kflex/version"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -39,21 +39,12 @@ var Version string
 var BuildDate string
 
 // REFACTOR: All global variables will disappear as each command package defines their own flags and retrieve then within cobra.Run function
-var createkind bool   // REFACTOR: to delete
 var kubeconfig string // REFACTOR: to delete
 
-var Hook string                         // REFACTOR: to delete
-var domain string                       // REFACTOR: to delete
-var externalPort int                    // REFACTOR: to delete
-var chattyStatus bool                   // REFACTOR: to delete
-var hookVars []string                   // REFACTOR: to delete
-var hostContainer string                // REFACTOR: to delete
-var overwriteExistingCtx bool           // REFACTOR: to delete
-var setCurrentCtxAsHosting bool         // REFACTOR: to delete
-var adoptedKubeconfig string            // REFACTOR: to delete
-var adoptedContext string               // REFACTOR: to delete
-var adoptedURLOverride string           // REFACTOR: to delete
-var adoptedTokenExpirationSeconds int64 // REFACTOR: to delete
+var Hook string                 // REFACTOR: to delete
+var chattyStatus bool           // REFACTOR: to delete
+var overwriteExistingCtx bool   // REFACTOR: to delete
+var setCurrentCtxAsHosting bool // REFACTOR: to delete
 
 var rootCmd = &cobra.Command{
 	Use:   "kflex",
@@ -63,21 +54,6 @@ var rootCmd = &cobra.Command{
 
 // REFACTOR: all commands of kflex (non root) are moving into their own command package
 // REFACTOR: to move to its own package (see how create command is implemented)
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Provide version info",
-	Long:  `Provide kubeflex version info for CLI`,
-	Args:  cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Kubeflex version: %s %s\n", Version, BuildDate)
-		kubeVersionInfo, err := util.GetKubernetesClusterVersionInfo(kubeconfig)
-		if err != nil {
-			fmt.Printf("Could not connect to a Kubernetes cluster: %s\n", err)
-			os.Exit(1)
-		}
-		fmt.Printf("Kubernetes version: %s\n", kubeVersionInfo)
-	},
-}
 
 // REFACTOR: to move to its own package (see how create command is implemented)
 
@@ -158,10 +134,9 @@ func init() {
 	// REFACTOR: to move to its own package (see how create command is implemented)
 	ctxCmd.AddCommand(ctxGetCmd)
 	ctxCmd.AddCommand(listCtxCmd)
-
-	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(ctxCmd)
 	// REFACTOR: call command from their respective package
+	rootCmd.AddCommand(version.Command())
 	rootCmd.AddCommand(kflexInit.Command())
 	rootCmd.AddCommand(adopt.Command())
 	rootCmd.AddCommand(delete.Command())

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kubestellar/kubeflex/cmd/kflex/adopt"
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
 	"github.com/kubestellar/kubeflex/cmd/kflex/create"
-	cont "github.com/kubestellar/kubeflex/cmd/kflex/ctx"
+	kflexCtx "github.com/kubestellar/kubeflex/cmd/kflex/ctx"
 	"github.com/kubestellar/kubeflex/cmd/kflex/delete"
 	kflexInit "github.com/kubestellar/kubeflex/cmd/kflex/init"
 	"github.com/kubestellar/kubeflex/cmd/kflex/list"
@@ -38,104 +38,18 @@ var Version string
 // BuildDate injected by makefile:LDFLAGS
 var BuildDate string
 
-// REFACTOR: All global variables will disappear as each command package defines their own flags and retrieve then within cobra.Run function
-var kubeconfig string // REFACTOR: to delete
-
-var Hook string                 // REFACTOR: to delete
-var chattyStatus bool           // REFACTOR: to delete
-var overwriteExistingCtx bool   // REFACTOR: to delete
-var setCurrentCtxAsHosting bool // REFACTOR: to delete
-
 var rootCmd = &cobra.Command{
 	Use:   "kflex",
 	Short: "CLI for kubeflex",
 	Long:  `A flexible and scalable solution for running Kubernetes control plane APIs`,
 }
 
-// REFACTOR: all commands of kflex (non root) are moving into their own command package
-// REFACTOR: to move to its own package (see how create command is implemented)
-
-// REFACTOR: to move to its own package (see how create command is implemented)
-
-// REFACTOR: to move to its own package (see how create command is implemented)
-// REFACTOR: remove cont.CPAdopt as common.CP is enough
-
-// REFACTOR: to move to its own package (see how create command is implemented)
-// REFACTOR: remove cont.CPDelete as common.CP is enough
-
-// REFACTOR: to move to its own package (see how create command is implemented)
-// REFACTOR: remove cont.CPCtx as common.CP is enough
-var ctxGetCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get the current kubeconfig context",
-	Long:  `Retrieve and display the current context from the kubeconfig file`,
-	Args:  cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		cp := cont.CPCtx{
-			CP: common.NewCP(kubeconfig),
-		}
-		cp.GetCurrentContext()
-	},
-}
-
-// REFACTOR: to move to its own package (see how create command is implemented)
-// REFACTOR: remove cont.CPCtx as common.CP is enough
-var ctxCmd = &cobra.Command{
-	Use:   "ctx",
-	Short: "Switch or get kubeconfig context",
-	Long: `Running without an argument switches the context back to the hosting cluster context,
-			        while providing the control plane name as argument switches the context to
-					that control plane. Use 'get' to retrieve the current context.`,
-	Args: cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		aliasName, _ := cmd.Flags().GetString("alias")
-		cpName := ""
-		if len(args) == 1 {
-			cpName = args[0]
-		}
-		cp := cont.CPCtx{
-			CP: common.NewCP(kubeconfig, common.WithName(cpName), common.WithAliasName(aliasName)),
-		}
-		cp.Context(chattyStatus, true, overwriteExistingCtx, setCurrentCtxAsHosting)
-	},
-}
-
-// REFACTOR: to move to its own package (see how create command is implemented)
-// REFACTOR: remove cont.CPCtx as common.CP is enough
-var listCtxCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all available contexts",
-	Long:  `List all available contexts in the kubeconfig file`,
-	Args:  cobra.ExactArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
-		cp := cont.CPCtx{
-			CP: common.NewCP(kubeconfig),
-		}
-		cp.ListContexts()
-	},
-}
-
 func init() {
-	// REFACTOR: init() will only define PersistentFlag and add Commands
-	// REFACTOR: PersistentFlags makes flag across commands and subcommands which is the behaviour expected prior refactoring
 	pflagset := rootCmd.PersistentFlags()
-	pflagset.StringP(common.KubeconfigFlag, "k", clientcmd.RecommendedFileName, "path to the kubeconfig file for the KubeFlex hosting cluster. If not specified, and $KUBECONFIG is set, it uses the value in $KUBECONFIG, otherwise it falls back to ${HOME}/.kube/config")
+	pflagset.StringP(common.KubeconfigFlag, "k", clientcmd.RecommendedHomeFile, "path to the kubeconfig file for the KubeFlex hosting cluster. If not specified, and $KUBECONFIG is set, it uses the value in $KUBECONFIG, otherwise it falls back to ${HOME}/.kube/config")
 	pflagset.BoolP(common.ChattyStatusFlag, "s", true, "chatty status indicator")
 	pflagset.IntP(common.VerbosityFlag, "v", 0, "log level") // TODO - figure out how to inject verbosity
-
-	// REFACTOR: to move to its own package (see how create command is implemented)
-
-	// REFACTOR: to move to its own package (see how create command is implemented)
-
-	// REFACTOR: to move to its own package (see how create command is implemented)
-	ctxCmd.Flags().BoolVarP(&overwriteExistingCtx, "overwrite-existing-context", "o", false, "Overwrite of hosting cluster context with new control plane context")
-	ctxCmd.Flags().BoolVarP(&setCurrentCtxAsHosting, "set-current-for-hosting", "c", false, "Set current context as hosting cluster context")
-	ctxCmd.Flags().String("alias", "", "Set an alias name as the context, user and cluster value instead of cp name")
-	// REFACTOR: to move to its own package (see how create command is implemented)
-	ctxCmd.AddCommand(ctxGetCmd)
-	ctxCmd.AddCommand(listCtxCmd)
-	rootCmd.AddCommand(ctxCmd)
-	// REFACTOR: call command from their respective package
+	rootCmd.AddCommand(kflexCtx.Command())
 	rootCmd.AddCommand(version.Command())
 	rootCmd.AddCommand(kflexInit.Command())
 	rootCmd.AddCommand(adopt.Command())

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -119,24 +119,6 @@ var initCmd = &cobra.Command{
 
 // REFACTOR: to move to its own package (see how create command is implemented)
 // REFACTOR: remove cont.CPAdopt as common.CP is enough
-var adoptCmd = &cobra.Command{
-	Use:   "adopt <name>",
-	Short: "Adopt a control plane from an external cluster",
-	Long: `Adopt a control plane from an external cluster and switches the Kubeconfig context to
-	        the current instance`,
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		cp := adopt.CPAdopt{
-			CP:                            common.NewCP(kubeconfig, common.WithName(args[0])),
-			AdoptedKubeconfig:             adoptedKubeconfig,
-			AdoptedContext:                adoptedContext,
-			AdoptedURLOverride:            adoptedURLOverride,
-			AdoptedTokenExpirationSeconds: adoptedTokenExpirationSeconds,
-		}
-		// create passing the control plane type and backend type
-		cp.Adopt(Hook, hookVars, chattyStatus)
-	},
-}
 
 // REFACTOR: to move to its own package (see how create command is implemented)
 // REFACTOR: remove cont.CPDelete as common.CP is enough
@@ -207,12 +189,7 @@ func init() {
 	initCmd.Flags().StringVarP(&hostContainer, "hostContainerName", "n", "kubeflex-control-plane", "Name of the hosting cluster container (kind or k3d only)")
 	initCmd.Flags().IntVarP(&externalPort, "externalPort", "p", 9443, "external port used by ingress")
 	// REFACTOR: to move to its own package (see how create command is implemented)
-	adoptCmd.Flags().StringVarP(&Hook, "postcreate-hook", "p", "", "name of post create hook to run")
-	adoptCmd.Flags().StringArrayVarP(&hookVars, "set", "e", []string{}, "set post create hook variables, in the form name=value ")
-	adoptCmd.Flags().StringVarP(&adoptedKubeconfig, "adopted-kubeconfig", "a", "", "path to the kubeconfig file for the adopted cluster. If unspecified, it uses the default Kubeconfig")
-	adoptCmd.Flags().StringVarP(&adoptedContext, "adopted-context", "c", "", "path to adopted cluster context in adopted kubeconfig")
-	adoptCmd.Flags().StringVarP(&adoptedURLOverride, "url-override", "u", "", "URL overrride for adopted cluster. Required when cluster address uses local host address, e.g. `https://127.0.0.1` ")
-	adoptCmd.Flags().Int64VarP(&adoptedTokenExpirationSeconds, "expiration-seconds", "x", 86400*365, "adopted token expiration in seconds. Default is one year.")
+
 	// REFACTOR: to move to its own package (see how create command is implemented)
 	ctxCmd.Flags().BoolVarP(&overwriteExistingCtx, "overwrite-existing-context", "o", false, "Overwrite of hosting cluster context with new control plane context")
 	ctxCmd.Flags().BoolVarP(&setCurrentCtxAsHosting, "set-current-for-hosting", "c", false, "Set current context as hosting cluster context")
@@ -223,9 +200,9 @@ func init() {
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)
-	rootCmd.AddCommand(adoptCmd)
 	rootCmd.AddCommand(ctxCmd)
 	// REFACTOR: call command from their respective package
+	rootCmd.AddCommand(adopt.Command())
 	rootCmd.AddCommand(delete.Command())
 	rootCmd.AddCommand(create.Command())
 	rootCmd.AddCommand(list.Command())

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -211,6 +211,7 @@ var ctxCmd = &cobra.Command{
 					that control plane. Use 'get' to retrieve the current context.`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		aliasName, _ := cmd.Flags().GetString("alias")
 		cpName := ""
 		if len(args) == 1 {
 			cpName = args[0]
@@ -219,6 +220,7 @@ var ctxCmd = &cobra.Command{
 			CP: common.CP{
 				Ctx:        createContext(),
 				Name:       cpName,
+				AliasName:  aliasName,
 				Kubeconfig: kubeconfig,
 			},
 		}
@@ -295,6 +297,7 @@ func init() {
 	ctxCmd.Flags().BoolVarP(&chattyStatus, "chatty-status", "s", true, "chatty status indicator")
 	ctxCmd.Flags().BoolVarP(&overwriteExistingCtx, "overwrite-existing-context", "o", false, "Overwrite of hosting cluster context with new control plane context")
 	ctxCmd.Flags().BoolVarP(&setCurrentCtxAsHosting, "set-current-for-hosting", "c", false, "Set current context as hosting cluster context")
+	ctxCmd.Flags().String("alias", "", "Set an alias name as the context, user and cluster value instead of cp name")
 
 	ctxCmd.AddCommand(ctxGetCmd)
 	ctxCmd.AddCommand(listCtxCmd)

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
 	"github.com/kubestellar/kubeflex/cmd/kflex/create"
 	cont "github.com/kubestellar/kubeflex/cmd/kflex/ctx"
-	del "github.com/kubestellar/kubeflex/cmd/kflex/delete"
+	"github.com/kubestellar/kubeflex/cmd/kflex/delete"
 	in "github.com/kubestellar/kubeflex/cmd/kflex/init"
 	cluster "github.com/kubestellar/kubeflex/cmd/kflex/init/cluster"
 	"github.com/kubestellar/kubeflex/cmd/kflex/list"
@@ -140,19 +140,6 @@ var adoptCmd = &cobra.Command{
 
 // REFACTOR: to move to its own package (see how create command is implemented)
 // REFACTOR: remove cont.CPDelete as common.CP is enough
-var deleteCmd = &cobra.Command{
-	Use:   "delete <name>",
-	Short: "Delete a control plane instance",
-	Long: `Delete a control plane instance and switches the context back to
-	        the hosting cluster context`,
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		cp := del.CPDelete{
-			CP: common.NewCP(kubeconfig, common.WithName(args[0])),
-		}
-		cp.Delete(chattyStatus)
-	},
-}
 
 // REFACTOR: to move to its own package (see how create command is implemented)
 // REFACTOR: remove cont.CPCtx as common.CP is enough
@@ -237,9 +224,9 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(adoptCmd)
-	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(ctxCmd)
 	// REFACTOR: call command from their respective package
+	rootCmd.AddCommand(delete.Command())
 	rootCmd.AddCommand(create.Command())
 	rootCmd.AddCommand(list.Command())
 }

--- a/cmd/kflex/version/version.go
+++ b/cmd/kflex/version/version.go
@@ -1,0 +1,35 @@
+package version
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/kubestellar/kubeflex/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "version",
+		Short: "Provide version info",
+		Long:  `Provide kubeflex version info for CLI`,
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			flagset := cmd.Flags()
+			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
+			execute(kubeconfig, common.Version, common.BuildDate)
+		},
+	}
+	return command
+}
+
+func execute(kubeconfig string, version string, buildDate string) {
+	fmt.Printf("Kubeflex version: %s %s\n", version, buildDate)
+	kubeVersionInfo, err := util.GetKubernetesClusterVersionInfo(kubeconfig)
+	if err != nil {
+		fmt.Printf("Could not connect to a Kubernetes cluster: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Kubernetes version: %s\n", kubeVersionInfo)
+}

--- a/cmd/kflex/version/version.go
+++ b/cmd/kflex/version/version.go
@@ -18,13 +18,13 @@ func Command() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			flagset := cmd.Flags()
 			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
-			execute(kubeconfig, common.Version, common.BuildDate)
+			ExecuteVersion(kubeconfig, common.Version, common.BuildDate)
 		},
 	}
 	return command
 }
 
-func execute(kubeconfig string, version string, buildDate string) {
+func ExecuteVersion(kubeconfig string, version string, buildDate string) {
 	fmt.Printf("Kubeflex version: %s %s\n", version, buildDate)
 	kubeVersionInfo, err := util.GetKubernetesClusterVersionInfo(kubeconfig)
 	if err != nil {

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -34,7 +34,7 @@ openssl x509 -noout -text -in certs/apiserver.crt
 ### Manually creating the configmap with KubeFlex defaults
 
 ```shell
-create configmap kubeflex-config -n kubeflex-system --from-literal=externalPort=9443 --from-literal=domain=localtest.me
+kubectl create configmap kubeflex-config -n kubeflex-system --from-literal=externalPort=9443 --from-literal=domain=localtest.me
 ```
 
 ### Get decoded value from secret

--- a/docs/users.md
+++ b/docs/users.md
@@ -79,7 +79,7 @@ helm install ingress-nginx ingress-nginx --set "controller.extraArgs.enable-ssl-
 
 
 ```shell
-kflex init --hostContainerName k3d-kubeflex-server-0
+kflex init --host-container-name k3d-kubeflex-server-0
 ```
 
 ### Installing on OpenShift

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -175,18 +175,18 @@ func WaitForNamespaceReady(ctx context.Context, clientset kubernetes.Interface, 
 func adjustConfigKeys(config *clientcmdapi.Config, cpName, controlPlaneType string) {
 	switch controlPlaneType {
 	case string(tenancyv1alpha1.ControlPlaneTypeOCM):
-		renameKey(config.Clusters, "multicluster-controlplane", certs.GenerateClusterName(cpName))
-		renameKey(config.AuthInfos, "user", certs.GenerateAuthInfoAdminName(cpName))
-		renameKey(config.Contexts, "multicluster-controlplane", certs.GenerateContextName(cpName))
+		RenameKey(config.Clusters, "multicluster-controlplane", certs.GenerateClusterName(cpName))
+		RenameKey(config.AuthInfos, "user", certs.GenerateAuthInfoAdminName(cpName))
+		RenameKey(config.Contexts, "multicluster-controlplane", certs.GenerateContextName(cpName))
 		config.CurrentContext = certs.GenerateContextName(cpName)
 		config.Contexts[certs.GenerateContextName(cpName)] = &clientcmdapi.Context{
 			Cluster:  certs.GenerateClusterName(cpName),
 			AuthInfo: certs.GenerateAuthInfoAdminName(cpName),
 		}
 	case string(tenancyv1alpha1.ControlPlaneTypeVCluster):
-		renameKey(config.Clusters, "my-vcluster", certs.GenerateClusterName(cpName))
-		renameKey(config.AuthInfos, "my-vcluster", certs.GenerateAuthInfoAdminName(cpName))
-		renameKey(config.Contexts, "my-vcluster", certs.GenerateContextName(cpName))
+		RenameKey(config.Clusters, "my-vcluster", certs.GenerateClusterName(cpName))
+		RenameKey(config.AuthInfos, "my-vcluster", certs.GenerateAuthInfoAdminName(cpName))
+		RenameKey(config.Contexts, "my-vcluster", certs.GenerateContextName(cpName))
 		config.CurrentContext = certs.GenerateContextName(cpName)
 		config.Contexts[certs.GenerateContextName(cpName)] = &clientcmdapi.Context{
 			Cluster:  certs.GenerateClusterName(cpName),
@@ -197,7 +197,7 @@ func adjustConfigKeys(config *clientcmdapi.Config, cpName, controlPlaneType stri
 	}
 }
 
-func renameKey(m interface{}, oldKey string, newKey string) interface{} {
+func RenameKey(m interface{}, oldKey string, newKey string) interface{} {
 	switch v := m.(type) {
 	case map[string]*clientcmdapi.Cluster:
 		if cluster, ok := v[oldKey]; ok {


### PR DESCRIPTION
# Proof-of-concept - READY TO MERGE

## Summary

Before this PR, a couple of parameters, types and others have been copy paste and did not leverage the power that spf13/cobra offers (reusability, modularity...)

To solve this problem, I decided to change the codebase design at the `cmd/kflex/` level. 

For this proof of concept, **ONLY** the commands listed below have been refactored and the code as it is currently would not build.
- `kflex create`
- `kflex list`

Overall, the design change vows to:
- simplify the codeflow which will make the OSS adoption by contributors easier
- avoid side-effects as much as possible, which could explain the number of bugs reported
- improve readability of the codebase with better naming convention, remove unecessary struct/types, better semantic
- be more idiomatic. My references are [Learn Go the Idiomatic way](https://www.oreilly.com/library/view/learning-go-2nd/9781098139285/) and [100 Mistakes in Go and how to avoid it](https://100go.co/)

**Note:** two types of comments are added within the codebase for this PoC
- `// REFACTOR:` explain the refactor made and consequences
- `// REFACTOR?` indicates a question -- should it be refactor?

## Code design

The new code design aims to alleviate the hassle of defining everything within the root file and aims to isolate command code within their own package to limit the dependencies between root and its commands.

### Project structure

It is inspired by domain-driven dev. To avoid cyclic import, the structure policy is the following:

```
cmd/kflex
├── common                   # shared package -- only package which does not represent commands but reusable types, functions and flags
│   ├── cp.go                # shared 
│   └── flags.go             # shared flags -- define global flags constants
├── create
│   └── create.go
├── ctx                      # package -- indicates command
│   ├── ctx.go               # command -- noticeable because matches package name
│   └── list.go              # any other files indicates they are subcommands
├── list
│   └── list.go
...
└── main.go                  # root command -- where kflex is defined
```

1. **Top-to-bottom direction**. A command cannot import/use root resources nor resources from its siblings `root --> commands --> subcommands ...`
2. **Shared package**. Only `common` package stores reusable resources callable by root command, its commands and subcommands. `common` is the only package not defining a command.
3. **Packages represent commands**. Definition of a command and its subcommand are made within its package: flags definition, code logic, subcommands.
4. **Files within command package**. A command is named after its package name, hence any file within a package with different naming would represent a subcommands. For instance `ctx/ctx.go` defines the `kflex ctx` whereas `ctx/list.go` defines the subcommand of ctx `kflex ctx list`. (NOT IMPLEMENTED IN THIS PoC !!!) --> *Note: in relation with #351, this structure will then allow to easily implement `kflex ctx rename` by creating `ctx/rename.go` file*

Proceding as follow makes every commands business-independant and has separation of concerns.

### spf13/cobra specificities

To avoid global variables within the root file, we make use of `FlagSet` which does not store CLI value within these variables. Instead, each command will define 

1. `func Command() *cobra.Command` which returns the command with its flags and execution code initialised.
2. `func execute(arguments...)` which represent the logic of the command (ie. create controlplane)

This guarentee that flags values passed cannot be modified by another process, which was a possibility before by the mean of global variables to store flag values. Now, `command.Flags().StringP` replaces `command.Flags().StringVarP`.

**NOTE:** the only global variables that may remains are those required by `gorelease` to inject values at compile time (such as `kflex version`).

To avoid memory consumption, `command.Flags()` is no longer call for each options. Instead, it instantiated once for one command in one execution, as shown here 
https://github.com/kubestellar/kubeflex/compare/main...rxinui:kubeflex:bug/308?expand=1#diff-20056e0c2eba9525b066cf3155bfc265204830faa73252b3ea4be36f4dd3b736R56-R65

Unnecessary `if-test` are replaced by the mean of cobra default values. See https://github.com/kubestellar/kubeflex/compare/main...rxinui:kubeflex:bug/308?expand=1#diff-20056e0c2eba9525b066cf3155bfc265204830faa73252b3ea4be36f4dd3b736R69-R73

### Better readability

Now, flags name are moved as constants. It will make OSS contribution easier when existing option for a given command should also be added to another one (for instance, `--set` flag define in `create` should be added to `ctx`). Shared flags are define in `common` package while command-specific flag are define within its command definition.

In the legacy codebase, a tricky/bad usage of variable name is done with control plane. In fact, `cp` is currently used as `var cp CP` but it gets overshadow by `tenancyv1alpha1.ControlPlane` type. This has been fix by improving variable naming. Now `cp` strictly refers to `common.CP` whereas `controlPlane` refers to `tenancyv1alpha1.ControlPlane`. See https://github.com/kubestellar/kubeflex/compare/main...rxinui:kubeflex:bug/308?expand=1#diff-97c377915d8ccea8cbc135426b489f90bae558e022c7c02310f2a02ecca99583R53-R89

(a) All struct variants of `CP` such as `CPCreate` or `CPList` are deleted as they are confusing and do not bring values. Instead, `CP` is now moved to `common` package and functions has been adapted to receive `CP` as function parameter rather than method parameter. See https://github.com/kubestellar/kubeflex/compare/main...rxinui:kubeflex:bug/308?expand=1#diff-97c377915d8ccea8cbc135426b489f90bae558e022c7c02310f2a02ecca99583R41

(b) Moreover, `CP` is now meant to be instantiated by the use of `NewCP` function. This factory implements the Option design pattern which allows optional parameters. That simplify a lot the codebase. We move from the old way

```go
cp := del.CPDelete{
			CP: common.CP{
				Ctx:        createContext(),
				Name:       args[0],
				Kubeconfig: kubeconfig,
			},
		}
```

to simply

```go
cp := common.NewCP(kubeconfig, common.WithName(args[0]))
```

In fact, `del.CPDelete` becomes irrelevant because of (a) and `NewCP` (b) embed `createContext()` process. With the option design pattern, it makes it easier with command that does not expect a `CP.Name` such as `listCtxCommand`. In such cases, we obtain

```go
cp := common.NewCP(kubeconfig)
```

## Related issue(s)

Fixes #308 
