### PR TITLE
✨ feature add default variables support for PostCreateHook

### DIFF
--- a/api/v1alpha1/postcreatehook_types.go
+++ b/api/v1alpha1/postcreatehook_types.go
@@ -21,9 +21,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// Var defines a name/value pair for template variables
+type Var struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // PostCreateHookSpec defines the desired state of PostCreateHook
 type PostCreateHookSpec struct {
 	Templates []Manifest `json:"templates,omitempty"`
+	DefaultVars []Var      `json:"defaultVars,omitempty"`
 }
 
 // PostCreateHookStatus defines the observed state of PostCreateHook

--- a/config/crd/bases/tenancy.kflex.kubestellar.org_postcreatehooks.yaml
+++ b/config/crd/bases/tenancy.kflex.kubestellar.org_postcreatehooks.yaml
@@ -55,6 +55,17 @@ spec:
           spec:
             description: PostCreateHookSpec defines the desired state of PostCreateHook
             properties:
+              defaultVars:
+                description: Default values for user-defined template variables
+                items:
+                  type: object
+                  required: [name, value]
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                type: array
               templates:
                 items:
                   description: Manifest represents a resource to be deployed

--- a/config/samples/postcreate-hooks/hello.yaml
+++ b/config/samples/postcreate-hooks/hello.yaml
@@ -3,6 +3,9 @@ kind: PostCreateHook
 metadata:
   name: hello
 spec:
+  defaultVars:
+    - name: "MESSAGE"
+      value: "Hello from Defaults"
   templates:
   - apiVersion: batch/v1
     kind: Job
@@ -14,6 +17,6 @@ spec:
           containers:
           - name: hello
             image: public.ecr.aws/docker/library/busybox:1.36
-            command: ["echo",  "Hello", "World"]
+            command: ["echo", "{{.MESSAGE}}", "World"]
           restartPolicy: Never
       backoffLimit: 1

--- a/docs/users.md
+++ b/docs/users.md
@@ -915,3 +915,19 @@ To list all available contexts in your kubeconfig file, use the following comman
 
 ```shell
 kflex ctx list
+```
+
+## PostCreateHook Template Variables
+
+PostCreateHooks support template variables with the following precedence:
+
+1. **System Variables** (highest priority)
+  - `Namespace`: Control plane namespace
+  - `ControlPlaneName`: Name of the control plane
+  - `HookName`: Name of the PostCreateHook
+
+2. **User Variables**  
+  Defined in `ControlPlane.spec.postCreateHookVars`
+
+3. **Default Variables**  
+  Defined in `PostCreateHook.spec.defaultVars`


### PR DESCRIPTION
## Summary
- Added `defaultVars` field to PostCreateHook API for defining default template variables
- Implemented variable resolution precedence: 
  - System variables (Namespace/ControlPlaneName/HookName) have highest priority
  - User-provided variables from ControlPlane override defaults
  - PostCreateHook defaults serve as base values
- Updated CRD validation schema with new field
- Added documentation examples for variable usage

Fixes: #233 