### PR TITLE
 🐛 fix: Allow deletion of contexts with invalid cluster connections

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -34,6 +34,11 @@ jobs:
 
       - name: Run test
         run: |
+          make install
+          kubectl apply -f config/samples/tenancy_v1alpha1_controlplane.yaml
+          
+          kubectl create namespace kubeflex-system --dry-run=client -o yaml | kubectl apply -f -
+          
           test/e2e/run.sh
 
       - name: Show kubeconfig contexts

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -34,11 +34,6 @@ jobs:
 
       - name: Run test
         run: |
-          make install
-          kubectl apply -f config/samples/tenancy_v1alpha1_controlplane.yaml
-          
-          kubectl create namespace kubeflex-system --dry-run=client -o yaml | kubectl apply -f -
-          
           test/e2e/run.sh
 
       - name: Show kubeconfig contexts


### PR DESCRIPTION
## Summary

🐛 Fix kflex delete command for faulty contexts:
- Forces switch to hosting cluster context before operations
- Handles missing control plane resources gracefully
- Ensures kubeconfig context cleanup even with invalid cluster connection
- Improves error handling for kubeconfig modifications

Fixes: #356