### PR TITLE
✨ add kflex ctx delete command 

### DIFF
--- a/cmd/kflex/common/flags.go
+++ b/cmd/kflex/common/flags.go
@@ -19,11 +19,11 @@ package common
 import "k8s.io/client-go/tools/clientcmd"
 
 const (
-	KubeconfigFlag     = clientcmd.RecommendedConfigPathFlag
-	ChattyStatusFlag   = "chatty-status"
-	VerbosityFlag      = "verbosity"
-	PostCreateHookFlag = "postcreate-hook"
-	SetFlag            = "set"
+	KubeconfigFlag     = clientcmd.RecommendedConfigPathFlag // String flag
+	ChattyStatusFlag   = "chatty-status"                     // Boolean flag
+	VerbosityFlag      = "verbosity"                         // Int flag
+	PostCreateHookFlag = "postcreate-hook"                   // String flag
+	SetFlag            = "set"                               // []String flag
 )
 
 // Version injected by makefile:LDFLAGS
@@ -31,3 +31,9 @@ var Version string
 
 // BuildDate injected by makefile:LDFLAGS
 var BuildDate string
+
+type KflexGlobalOptions interface {
+	WithChattyStatus(chattyStatus bool)
+	WithVerbosity(verbosity int)
+	WithKubeconfig(kubeconfig string)
+}

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -71,7 +71,7 @@ func Command() *cobra.Command {
 	flagset := command.Flags()
 	flagset.BoolP(OverwriteExistingContextFlag, "o", false, "Overwrite of hosting cluster context with new control plane context")
 	flagset.BoolP(SetCurrentForHostingFlag, "c", false, "Set current context as hosting cluster context")
-	command.AddCommand(CommandGet(), CommandList(), CommandRename())
+	command.AddCommand(CommandGet(), CommandList(), CommandRename(), CommandDelete())
 	return command
 }
 
@@ -115,7 +115,7 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 		// Switch to given context
 		if overwriteExistingCtx {
 			util.PrintStatus("Overwriting existing context for control plane", done, &wg, chattyStatus)
-			if err = kubeconfig.DeleteContext(kconf, cpCtx.Name); err != nil {
+			if err = kubeconfig.DeleteAll(kconf, cpCtx.Name); err != nil {
 				fmt.Fprintf(os.Stderr, "no kubeconfig context for %s was found: %s\n", cpCtx.Name, err)
 			}
 			done <- true

--- a/cmd/kflex/ctx/ctx_test.go
+++ b/cmd/kflex/ctx/ctx_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ctx
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kubestellar/kubeflex/pkg/certs"
+	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+var kubeconfigPath string = "./testconfig"
+var hostingClusterContextMock = "default"
+
+// Setup mock kubeconfig file with context,cluster,authinfo
+func setupMockContext(kubeconfigPath string, ctxName string) error {
+	kconf := api.NewConfig()
+	kconf.Contexts[certs.GenerateContextName(ctxName)] = &api.Context{
+		Cluster:  certs.GenerateClusterName(ctxName),
+		AuthInfo: certs.GenerateAuthInfoAdminName(ctxName),
+	}
+	kconf.Clusters[certs.GenerateClusterName(ctxName)] = api.NewCluster()
+	kconf.AuthInfos[certs.GenerateAuthInfoAdminName(ctxName)] = api.NewAuthInfo()
+	kconf.CurrentContext = hostingClusterContextMock
+	kubeconfig.SetHostingClusterContextPreference(kconf, nil)
+	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
+		return fmt.Errorf("error writing kubeconfig: %v", err)
+	}
+	return nil
+}
+
+// Delete mock kubeconfig file
+func teardown(kubeconfigPath string) error {
+	return os.Remove(kubeconfigPath)
+}

--- a/cmd/kflex/ctx/delete.go
+++ b/cmd/kflex/ctx/delete.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ctx
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+	"github.com/kubestellar/kubeflex/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+func CommandDelete() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete CONTEXT",
+		Short: "Delete a context",
+		Long:  `Delete a context in the kubeconfig file`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			kubeconfig, _ := cmd.Flags().GetString(common.KubeconfigFlag)
+			chattyStatus, _ := cmd.Flags().GetBool(common.ChattyStatusFlag)
+			cp := common.NewCP(kubeconfig, common.WithName(args[0]))
+			return ExecuteCtxDelete(cp, chattyStatus)
+		},
+	}
+}
+
+// Execute kflex ctx delete
+func ExecuteCtxDelete(cp common.CP, chattyStatus bool) error {
+	var wg sync.WaitGroup
+	done := make(chan bool)
+	util.PrintStatus("Deleting context", done, &wg, chattyStatus)
+	kconf, err := kubeconfig.LoadKubeconfig(cp.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("error loading kubeconfig: %v", err)
+	}
+	if err = kubeconfig.DeleteAll(kconf, cp.Name); err != nil {
+		return fmt.Errorf("error deleting context %s from kubeconfig: %v", cp.Name, err)
+	}
+	if err = kubeconfig.WriteKubeconfig(cp.Kubeconfig, kconf); err != nil {
+		return fmt.Errorf("error writing kubeconfig: %v", err)
+	}
+	done <- true
+	wg.Wait()
+	return nil
+}

--- a/cmd/kflex/ctx/delete.go
+++ b/cmd/kflex/ctx/delete.go
@@ -18,10 +18,13 @@ package ctx
 
 import (
 	"fmt"
+	"sync"
+
 	// "sync"
 
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
 	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+	"github.com/kubestellar/kubeflex/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -43,6 +46,9 @@ func CommandDelete() *cobra.Command {
 
 // Execute kflex ctx delete
 func ExecuteCtxDelete(cp common.CP, ctxName string, chattyStatus bool) error {
+	var wg sync.WaitGroup
+	done := make(chan bool)
+	util.PrintStatus("Deleting context", done, &wg, chattyStatus)
 	kconf, err := kubeconfig.LoadKubeconfig(cp.Kubeconfig)
 	if err != nil {
 		return fmt.Errorf("error loading kubeconfig: %v", err)
@@ -57,5 +63,7 @@ func ExecuteCtxDelete(cp common.CP, ctxName string, chattyStatus bool) error {
 	if err = kubeconfig.WriteKubeconfig(cp.Kubeconfig, kconf); err != nil {
 		return fmt.Errorf("error writing kubeconfig: %v", err)
 	}
+	done <- true
+	wg.Wait()
 	return nil
 }

--- a/cmd/kflex/ctx/delete_test.go
+++ b/cmd/kflex/ctx/delete_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ctx
+
+import (
+	"testing"
+
+	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/kubestellar/kubeflex/pkg/certs"
+	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+)
+
+// Test delete a context that exist and checks that it is removed
+// from the kubeconfig
+func TestDeleteOk(t *testing.T) {
+	ctxName := "cptobedeleted"
+	setupMockContext(kubeconfigPath, ctxName)
+	defer teardown(kubeconfigPath)
+
+	// Start test
+	cp := common.NewCP(kubeconfigPath, common.WithName(ctxName))
+	err := ExecuteCtxDelete(cp, ctxName, false)
+	if err != nil {
+		t.Errorf("failed to run 'kflex ctx delete %s': %v", ctxName, err)
+	}
+	kconf, err := kubeconfig.LoadKubeconfig(kubeconfigPath)
+	if err != nil {
+		t.Errorf("error loading kubeconfig: %v", err)
+	}
+	clusterName := certs.GenerateClusterName(ctxName)
+	authInfoName := certs.GenerateAuthInfoAdminName(ctxName)
+	if c, ok := kconf.Contexts[ctxName]; ok {
+		t.Errorf("context '%v' still present in kubeconfig", c)
+	}
+	if c, ok := kconf.Clusters[clusterName]; ok {
+		t.Errorf("cluster '%v' still present in kubeconfig", c)
+	}
+	if c, ok := kconf.AuthInfos[authInfoName]; ok {
+		t.Errorf("user '%v' still present in kubeconfig", c)
+	}
+	if kconf.CurrentContext == ctxName {
+		t.Errorf("current context must not be set as the deleted context %s", ctxName)
+	}
+}
+
+// Test delete on non-existent context and checks that the kubeconfig is unchanged
+func TestDeleteNonExistentContext(t *testing.T) {
+	ctxName := "cptobedeleted"
+	noneCtxName := "none"
+	setupMockContext(kubeconfigPath, ctxName)
+	defer teardown(kubeconfigPath)
+
+	// Start test
+	cp := common.NewCP(kubeconfigPath, common.WithName(ctxName))
+	kconf, err := kubeconfig.LoadKubeconfig(kubeconfigPath)
+	if err != nil {
+		t.Errorf("error loading kubeconfig: %v", err)
+	}
+	nCtx := len(kconf.Contexts)
+	err = ExecuteCtxDelete(cp, noneCtxName, false)
+	if err == nil {
+		t.Errorf("expect ExecuteCtxDelete to fail but it succeeded")
+	}
+	if nCtx != len(kconf.Contexts) {
+		t.Errorf("expect ExecuteCtxDelete to not delete any context but it did")
+	}
+}

--- a/cmd/kflex/ctx/rename.go
+++ b/cmd/kflex/ctx/rename.go
@@ -76,8 +76,6 @@ func ExecuteCtxRename(cp common.CP, ctxName string, newCtxName string, toSwitch 
 		newAuthInfo := *authInfo
 		kconf.AuthInfos[newAuthInfoAdminName] = &newAuthInfo
 	}
-	fmt.Printf("kconf-clusters: %v\n", kconf.Clusters)
-	fmt.Printf("kconf-auths: %v\n", kconf.AuthInfos)
 	fmt.Fprintf(os.Stdout, "renaming context from %s to %s\n", ctxName, newCtxName)
 	if err = kubeconfig.DeleteAll(kconf, ctxName); err != nil {
 		return fmt.Errorf("cannot delete context %s from kubeconfig: %v", ctxName, err)

--- a/cmd/kflex/ctx/rename.go
+++ b/cmd/kflex/ctx/rename.go
@@ -79,7 +79,7 @@ func ExecuteCtxRename(cp common.CP, ctxName string, newCtxName string, toSwitch 
 	fmt.Printf("kconf-clusters: %v\n", kconf.Clusters)
 	fmt.Printf("kconf-auths: %v\n", kconf.AuthInfos)
 	fmt.Fprintf(os.Stdout, "renaming context from %s to %s\n", ctxName, newCtxName)
-	if err = kubeconfig.DeleteContext(kconf, ctxName); err != nil {
+	if err = kubeconfig.DeleteAll(kconf, ctxName); err != nil {
 		return fmt.Errorf("cannot delete context %s from kubeconfig: %v", ctxName, err)
 	}
 	fmt.Fprintf(os.Stdout, "context %s is deleted\n", ctxName)

--- a/cmd/kflex/ctx/rename_test.go
+++ b/cmd/kflex/ctx/rename_test.go
@@ -18,38 +18,12 @@ package ctx
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
 	"github.com/kubestellar/kubeflex/pkg/certs"
 	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
-	"k8s.io/client-go/tools/clientcmd/api"
 )
-
-var kubeconfigPath string = "./testconfig"
-var hostingClusterContextMock = "default"
-
-func setupMockContext(kubeconfigPath string, ctxName string) error {
-	kconf := api.NewConfig()
-	kconf.Contexts[certs.GenerateContextName(ctxName)] = &api.Context{
-		Cluster:  certs.GenerateClusterName(ctxName),
-		AuthInfo: certs.GenerateAuthInfoAdminName(ctxName),
-	}
-	kconf.Clusters[certs.GenerateClusterName(ctxName)] = api.NewCluster()
-	kconf.AuthInfos[certs.GenerateAuthInfoAdminName(ctxName)] = api.NewAuthInfo()
-	kconf.CurrentContext = hostingClusterContextMock
-	kubeconfig.SetHostingClusterContextPreference(kconf, nil)
-	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
-		return fmt.Errorf("error writing kubeconfig: %v", err)
-	}
-	return nil
-}
-
-func teardown(kubeconfigPath string) error {
-	os.Remove(kubeconfigPath)
-	return nil
-}
 
 func TestRenameOk(t *testing.T) {
 	// Mock data

--- a/cmd/kflex/delete/delete.go
+++ b/cmd/kflex/delete/delete.go
@@ -19,17 +19,16 @@ package delete
 import (
 	"context"
 	"fmt"
-	"os"
 	"sync"
 
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientK8s "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
-	kfclient "github.com/kubestellar/kubeflex/pkg/client"
+	clientKubeflex "github.com/kubestellar/kubeflex/pkg/client"
 	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
 	"github.com/kubestellar/kubeflex/pkg/util"
 )
@@ -38,20 +37,20 @@ func Command() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete a control plane instance",
-		Long: `Delete a control plane instance and switches the context back to
-				the hosting cluster context`,
-		Args: cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		Long:  `Delete a control plane instance and switches the context back to the hosting cluster context`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			flagset := cmd.Flags()
 			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
 			chattyStatus, _ := flagset.GetBool(common.ChattyStatusFlag)
 			cp := common.NewCP(kubeconfig, common.WithName(args[0]))
-			ExecuteDelete(cp, chattyStatus)
+			return ExecuteDelete(cp, chattyStatus)
 		},
 	}
 }
 
-func ExecuteDelete(cp common.CP, chattyStatus bool) {
+func ExecuteDelete(cp common.CP, chattyStatus bool) error {
 	done := make(chan bool)
 	controlPlane := &tenancyv1alpha1.ControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -63,58 +62,50 @@ func ExecuteDelete(cp common.CP, chattyStatus bool) {
 	util.PrintStatus(fmt.Sprintf("Deleting control plane %s...", cp.Name), done, &wg, chattyStatus)
 	kconf, err := kubeconfig.LoadKubeconfig(cp.Kubeconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading kubeconfig: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error loading kubeconfig: %v", err)
 	}
 
 	if err = kubeconfig.SwitchToHostingClusterContext(kconf, false); err != nil {
-		fmt.Fprintf(os.Stderr, "error switching to hosting cluster kubeconfig context: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error switching to hosting cluster kubeconfig context: %v", err)
 	}
 
 	if err := kubeconfig.WriteKubeconfig(cp.Kubeconfig, kconf); err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing kubeconfig: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error writing kubeconfig: %v", err)
 	}
 
-	kfcClient, err := kfclient.GetClient(cp.Kubeconfig)
+	clientKflex, err := clientKubeflex.GetClient(cp.Kubeconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error getting kf client: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error getting kubeflex client: %v", err)
 	}
 
-	if err := kfcClient.Get(context.TODO(), client.ObjectKeyFromObject(controlPlane), controlPlane, &client.GetOptions{}); err != nil {
-		fmt.Fprintf(os.Stderr, "control plane not found on server: %s", err)
+	if err := clientKflex.Get(context.TODO(), clientK8s.ObjectKeyFromObject(controlPlane), controlPlane, &clientK8s.GetOptions{}); err != nil {
+		return fmt.Errorf("control plane not found on server: %v", err)
 	}
 
-	if err := kfcClient.Delete(context.TODO(), controlPlane, &client.DeleteOptions{}); err != nil {
-		fmt.Fprintf(os.Stderr, "Error deleting instance: %s\n", err)
-		os.Exit(1)
+	if err := clientKflex.Delete(context.TODO(), controlPlane, &clientK8s.DeleteOptions{}); err != nil {
+		return fmt.Errorf("error deleting instance: %v", err)
 	}
 	done <- true
 
-	clientsetp, err := kfclient.GetClientSet(cp.Kubeconfig)
+	clientsetKflex, err := clientKubeflex.GetClientSet(cp.Kubeconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error getting kf client: %s\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error getting kf client: %v", err)
 	}
-	clientset := *clientsetp
 	util.PrintStatus(fmt.Sprintf("Waiting for control plane %s to be deleted...", cp.Name), done, &wg, chattyStatus)
-	util.WaitForNamespaceDeletion(clientset, util.GenerateNamespaceFromControlPlaneName(cp.Name))
+	util.WaitForNamespaceDeletion(*clientsetKflex, util.GenerateNamespaceFromControlPlaneName(cp.Name))
 
 	if controlPlane.Spec.Type != tenancyv1alpha1.ControlPlaneTypeHost &&
 		controlPlane.Spec.Type != tenancyv1alpha1.ControlPlaneTypeExternal {
 		if err := kubeconfig.DeleteContext(kconf, cp.Name); err != nil {
-			fmt.Fprintf(os.Stderr, "no kubeconfig context for %s was found: %s\n", cp.Name, err)
-			os.Exit(1)
+			return fmt.Errorf("no kubeconfig context for %s was found: %s", cp.Name, err)
 		}
 
 		if err := kubeconfig.WriteKubeconfig(cp.Kubeconfig, kconf); err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing kubeconfig: %s\n", err)
-			os.Exit(1)
+			return fmt.Errorf("error writing kubeconfig: %v", err)
 		}
 	}
 
 	done <- true
 	wg.Wait()
+	return nil
 }

--- a/cmd/kflex/delete/delete.go
+++ b/cmd/kflex/delete/delete.go
@@ -96,7 +96,7 @@ func ExecuteDelete(cp common.CP, chattyStatus bool) error {
 
 	if controlPlane.Spec.Type != tenancyv1alpha1.ControlPlaneTypeHost &&
 		controlPlane.Spec.Type != tenancyv1alpha1.ControlPlaneTypeExternal {
-		if err := kubeconfig.DeleteContext(kconf, cp.Name); err != nil {
+		if err := kubeconfig.DeleteAll(kconf, cp.Name); err != nil {
 			return fmt.Errorf("no kubeconfig context for %s was found: %s", cp.Name, err)
 		}
 

--- a/docs/users.md
+++ b/docs/users.md
@@ -699,6 +699,9 @@ cluster: mycp-renamed-cluster
 user: mycp-renamed-admin
 ```
 
+### `kflex ctx delete CONTEXT`
+
+Delete a context within your kubeconfig file. If the context deleted is your current context, `kflex` automatically switch your current context to the hosting cluster.
 
 ## Post-create hooks
 

--- a/pkg/kubeconfig/config-util.go
+++ b/pkg/kubeconfig/config-util.go
@@ -66,7 +66,7 @@ func SwitchContext(config *clientcmdapi.Config, cpName string) error {
 	return nil
 }
 
-func DeleteContext(config *clientcmdapi.Config, cpName string) error {
+func DeleteAll(config *clientcmdapi.Config, cpName string) error {
 	ctxName := certs.GenerateContextName(cpName)
 	clusterName := certs.GenerateClusterName(cpName)
 	authName := certs.GenerateAuthInfoAdminName(cpName)

--- a/test/e2e/manage-ctx.sh
+++ b/test/e2e/manage-ctx.sh
@@ -47,3 +47,16 @@ NEW_CTX_NAME="cp-renamed"
 [[ $(kubectl config view | grep -c "name: $NEW_CTX_NAME") -ne 3 ]] && exit 1
 [[ $(kubectl config view | grep -c "name: $CTX_NAME") -ne 0 ]] && exit 1
 echo "TEST: kflex ctx rename PASSED"
+
+:
+: -------------------------------------------------------------------------
+: Delete context $NEW_CTX_NAME and verify it is removed from kubeconfig file
+:
+./bin/kflex ctx delete ${NEW_CTX_NAME}
+
+:
+: -------------------------------------------------------------------------
+: Check $NEW_CTX_NAME is removed from kubeconfig file
+:
+[[ $(kubectl config view | grep -c "name: $NEW_CTX_NAME") -ne 0 ]] && exit 1
+echo "TEST: kflex ctx delete PASSED"


### PR DESCRIPTION
## Summary

Proposal PR -- as issue is not yet accepted, the following solution is proposed to give details and working implementation

`kflex ctx delete` subcommand is now added to allow user removing orphans context (created during dev phase).

This command properly clean useless contexts and its cluster and user of the kubeconfig.

**Note:** in the continuity of #352 and its refactoring process, the following has been added to improve the codeflow:

### Continuous improvement 

- **Explicit naming to avoid confusion**. `kubeconfig.DeleteContext` is renamed to `kubeconfig.DeleteAll` as the method delete the triple **context,cluster,user** from the kubeconfig, not just the context as implied by the signature.

- **Better error handling**. Instead of abruptly stop the codeflow using
```
fmt.FPrintf(err) // first display error
os.exit(1) // then exit
```
We replace `cobra.Command.Run` by `cobra.Command.RunE` which returns an `error` at the CLI-level runtime (as [written here](https://github.com/kubestellar/kubeflex/pull/359/files#diff-96eedf9e25c0f4a1893713a906be511d997c1709b08edc1f054ed5001cee7456R35-R40))

Leveraging that, we can simply return an error within our functions which reduce the number of instructions and make the code more idiomatic (reference https://100go.co/#ignoring-when-to-wrap-an-error-49):
```
return fmt.Errorf("error: %v", err) // transformation of new error using %v
```

### Notes

@pdettori if you approve this continuous improvement, the other commands and subcommands will need to be updated in a follow up PR to include this refactoring.

At the moment only `cmd/kflex/ctx/delete.go` includes the changes.

## Related issue(s)

Fixes #358 
