### PR TITLE
✨  Bump version of kube-rbac-proxy image from 0.18.0 to 0.19.1

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -36,6 +36,9 @@ jobs:
         run: |
           test/e2e/run.sh
 
+      - name: Examine GitHub rate limit
+        run: curl https://api.github.com/rate_limit
+
       - name: Show kubeconfig contexts
         if: always()
         run: kubectl config get-contexts

--- a/chart/templates/operator.yaml
+++ b/chart/templates/operator.yaml
@@ -591,7 +591,7 @@ spec:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
-        image: quay.io/brancz/kube-rbac-proxy:v0.18.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -41,7 +41,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: quay.io/brancz/kube-rbac-proxy:v0.18.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR bumps the version of the quay.io/brancz/kube-rbac-proxy image used in the kubestellar-controller-manager Deployment from v0.18.0 to v0.19.1. The benefit is fewer security vulnerabilities. The downside is that v0.19.1 is built on Kubernetes 1.31, while the rest of KubeFlex uses Kubernetes 1.30. I suspect that this inconsistency will not be problematic because of the narrow job of this particular image.

## Related issue(s)

Fixes #
