### PR TITLE
feature: implemented multiple PostCreateHooks with backward compatibility

### DIFF
--- a/api/v1alpha1/controlplane_types.go
+++ b/api/v1alpha1/controlplane_types.go
@@ -22,18 +22,29 @@ import (
 
 // ControlPlaneSpec defines the desired state of ControlPlane
 type ControlPlaneSpec struct {
-	Type    ControlPlaneType `json:"type,omitempty"`
-	Backend BackendDBType    `json:"backend,omitempty"`
-	// bootstrapSecretRef contains a reference to the kubeconfig used to bootstrap adoption of
-	// an external cluster
-	// +optional
-	BootstrapSecretRef *BootstrapSecretReference `json:"bootstrapSecretRef,omitempty"`
-	// tokenExpirationSeconds is the expiration time for generated auth token
-	// +optional
-	// +kubebuilder:default:=31536000
-	TokenExpirationSeconds *int64            `json:"tokenExpirationSeconds,omitempty"`
-	PostCreateHook         *string           `json:"postCreateHook,omitempty"`
-	PostCreateHookVars     map[string]string `json:"postCreateHookVars,omitempty"`
+    Type    ControlPlaneType `json:"type,omitempty"`
+    Backend BackendDBType    `json:"backend,omitempty"`
+    // bootstrapSecretRef contains a reference to the kubeconfig used to bootstrap adoption of
+    // an external cluster
+    // +optional
+    BootstrapSecretRef *BootstrapSecretReference `json:"bootstrapSecretRef,omitempty"`
+    // tokenExpirationSeconds is the expiration time for generated auth token
+    // +optional
+    // +kubebuilder:default:=31536000
+    TokenExpirationSeconds *int64            `json:"tokenExpirationSeconds,omitempty"`
+    // Deprecated: Use PostCreateHooks instead
+    PostCreateHook         *string           `json:"postCreateHook,omitempty"`
+    // Deprecated: Use PostCreateHooks instead
+    PostCreateHookVars     map[string]string `json:"postCreateHookVars,omitempty"`
+    // PostCreateHooks specifies multiple post-creation hooks to execute
+    PostCreateHooks        []PostCreateHookUse `json:"postCreateHooks,omitempty"`
+}
+
+type PostCreateHookUse struct {
+    // Name of the PostCreateHook resource to execute
+    HookName *string           `json:"hookName"`
+    // Variables to pass to the hook template
+    Vars     map[string]string `json:"vars,omitempty"`
 }
 
 // ControlPlaneStatus defines the observed state of ControlPlane

--- a/config/crd/bases/tenancy.kflex.kubestellar.org_controlplanes.yaml
+++ b/config/crd/bases/tenancy.kflex.kubestellar.org_controlplanes.yaml
@@ -84,11 +84,30 @@ spec:
                 - namespace
                 type: object
               postCreateHook:
+                description: 'Deprecated: Use PostCreateHooks instead'
                 type: string
               postCreateHookVars:
                 additionalProperties:
                   type: string
+                description: 'Deprecated: Use PostCreateHooks instead'
                 type: object
+              postCreateHooks:
+                description: PostCreateHooks specifies multiple post-creation hooks
+                  to execute
+                items:
+                  properties:
+                    hookName:
+                      description: Name of the PostCreateHook resource to execute
+                      type: string
+                    vars:
+                      additionalProperties:
+                        type: string
+                      description: Variables to pass to the hook template
+                      type: object
+                  required:
+                  - hookName
+                  type: object
+                type: array
               tokenExpirationSeconds:
                 default: 31536000
                 description: tokenExpirationSeconds is the expiration time for generated

--- a/config/crd/bases/tenancy.kflex.kubestellar.org_postcreatehooks.yaml
+++ b/config/crd/bases/tenancy.kflex.kubestellar.org_postcreatehooks.yaml
@@ -56,15 +56,17 @@ spec:
             description: PostCreateHookSpec defines the desired state of PostCreateHook
             properties:
               defaultVars:
-                description: Default values for user-defined template variables
                 items:
-                  type: object
-                  required: [name, value]
+                  description: Var defines a name/value pair for template variables
                   properties:
                     name:
                       type: string
                     value:
                       type: string
+                  required:
+                  - name
+                  - value
+                  type: object
                 type: array
               templates:
                 items:


### PR DESCRIPTION
# Summary

## In `api/v1alpha1/controlplane_types.go`
 - Add PostCreateHooks field for multiple hooks
 - Deprecate legacy single hook fields
 - Add PostCreateHookUse struct

## In `pkg/reconcilers/shared/postcreate_hook.go`
 - Process both legacy and new hooks
 - Handle multiple hooks in sequence
 - Update status per hook

## Backward Compatibility Strategy
**Old Fields**: Continue to work as before but are marked deprecated.

**New Fields**: Allow multiple hooks via `PostCreateHooks`.

**Reconciler**: Processes both old and new fields, merging them into a single list.

This ensures existing users using `postCreateHook` and `postCreateHookVars` are unaffected, while new users can adopt `postCreateHooks`. The CLI can be updated separately to support multiple hooks via new flags while maintaining backward compatibility with the old ones.

Fixes #225 
