### PR TITLE
✨ Usage of Extensions

### DIFF
--- a/cmd/kflex/common/flags.go
+++ b/cmd/kflex/common/flags.go
@@ -32,6 +32,9 @@ var Version string
 // BuildDate injected by makefile:LDFLAGS
 var BuildDate string
 
+// WarningMessage injected by makefile:LDFLAGS
+var WarningMessage string
+
 type KflexGlobalOptions interface {
 	WithChattyStatus(chattyStatus bool)
 	WithVerbosity(verbosity int)

--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -135,6 +135,7 @@ func ExecuteCreate(cp common.CP, controlPlaneType string, backendType string, ho
 	if err = kubeconfig.AssignControlPlaneToContext(kconf, cp.Name, certs.GenerateContextName(cp.Name)); err != nil {
 		return fmt.Errorf("error assigning control plane to context as kubeconfig extension: %v", err)
 	}
+	
 	kubeconfig.WriteKubeconfig(cp.Kubeconfig, kconf)
 	wg.Wait()
 	return nil

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -94,7 +94,7 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 		util.PrintStatus("Checking for saved hosting cluster context...", done, &wg, chattyStatus)
 		time.Sleep(1 * time.Second)
 		done <- true
-		if kubeconfig.IsHostingClusterContextPreferenceSet(kconf) {
+		if kubeconfig.IsHostingClusterContextSet(kconf) {
 			util.PrintStatus("Switching to hosting cluster context...", done, &wg, chattyStatus)
 			if err = kubeconfig.SwitchToHostingClusterContext(kconf, false); err != nil {
 				return fmt.Errorf("error switching kubeconfig to hosting cluster context: %v", err)
@@ -198,7 +198,7 @@ func (cpCtx *CPCtx) loadAndMergeFromServer(kconfig *api.Config) error {
 }
 
 func (cpCtx *CPCtx) switchToHostingClusterContextAndWrite(kconf *api.Config) error {
-	if kubeconfig.IsHostingClusterContextPreferenceSet(kconf) {
+	if kubeconfig.IsHostingClusterContextSet(kconf) {
 		if err := kubeconfig.SwitchToHostingClusterContext(kconf, false); err != nil {
 			return err
 		}

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -89,7 +89,7 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 	if cpCtx.Name == "" {
 		// Switch to hosting cluster context when no context is provided
 		if setCurrentCtxAsHosting { // set hosting cluster context unconditionally to the current context
-			err = kubeconfig.SetHostingClusterContextPreference(kconf, nil)
+			err = kubeconfig.SetHostingClusterContext(kconf, nil)
 			if err != nil {
 				return fmt.Errorf("error on ExecuteCtx: %v", err)
 			}
@@ -117,7 +117,7 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 
 			}
 			util.PrintStatus("Hosting cluster context not set, setting it to current context", done, &wg, chattyStatus)
-			err = kubeconfig.SetHostingClusterContextPreference(kconf, nil)
+			err = kubeconfig.SetHostingClusterContext(kconf, nil)
 			if err != nil {
 				return fmt.Errorf("error on ExecuteCtx: %v", err)
 			}

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -89,7 +89,10 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 	if cpCtx.Name == "" {
 		// Switch to hosting cluster context when no context is provided
 		if setCurrentCtxAsHosting { // set hosting cluster context unconditionally to the current context
-			kubeconfig.SetHostingClusterContextPreference(kconf, nil)
+			err = kubeconfig.SetHostingClusterContextPreference(kconf, nil)
+			if err != nil {
+				return fmt.Errorf("error on ExecuteCtx: %v", err)
+			}
 		}
 		util.PrintStatus("Checking for saved hosting cluster context...", done, &wg, chattyStatus)
 		time.Sleep(1 * time.Second)
@@ -114,7 +117,10 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 
 			}
 			util.PrintStatus("Hosting cluster context not set, setting it to current context", done, &wg, chattyStatus)
-			kubeconfig.SetHostingClusterContextPreference(kconf, nil)
+			err = kubeconfig.SetHostingClusterContextPreference(kconf, nil)
+			if err != nil {
+				return fmt.Errorf("error on ExecuteCtx: %v", err)
+			}
 			done <- true
 		}
 	} else {

--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -99,7 +99,7 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 		done <- true
 		if kubeconfig.IsHostingClusterContextSet(kconf) {
 			util.PrintStatus("Switching to hosting cluster context...", done, &wg, chattyStatus)
-			if err = kubeconfig.SwitchToHostingClusterContext(kconf, false); err != nil {
+			if err = kubeconfig.SwitchToHostingClusterContext(kconf); err != nil {
 				return fmt.Errorf("error switching kubeconfig to hosting cluster context: %v", err)
 
 			}
@@ -113,7 +113,7 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 				return fmt.Errorf("the hosting cluster context is not known!\n" +
 					"you can make it known to kflex by doing `kubectl config use-context` \n" +
 					"to set the current context to the hosting cluster context and then using \n" +
-					"`kflex ctx --set-current-for-hosting` to restore the needed kubeconfig extension.")
+					"`kflex ctx --set-current-for-hosting` to restore the needed kubeconfig extension")
 
 			}
 			util.PrintStatus("Hosting cluster context not set, setting it to current context", done, &wg, chattyStatus)
@@ -166,7 +166,7 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 	return nil
 }
 
-func (cpCtx *CPCtx) loadAndMergeFromServer(kconfig *api.Config) error {
+func (cpCtx *CPCtx) loadAndMergeFromServer(kconf *api.Config) error {
 	kfcClient, err := kfclient.GetClient(cpCtx.Kubeconfig)
 	if err != nil {
 		return fmt.Errorf("error getting kf client: %s", err)
@@ -185,7 +185,7 @@ func (cpCtx *CPCtx) loadAndMergeFromServer(kconfig *api.Config) error {
 
 	// for control plane of type host just switch to initial context
 	if cp.Spec.Type == tenancyv1alpha1.ControlPlaneTypeHost {
-		return kubeconfig.SwitchToHostingClusterContext(kconfig, false)
+		return kubeconfig.SwitchToHostingClusterContext(kconf)
 	}
 
 	// for all other control planes need to get secret with off-cluster kubeconfig
@@ -196,7 +196,7 @@ func (cpCtx *CPCtx) loadAndMergeFromServer(kconfig *api.Config) error {
 	}
 	clientset := *clientsetp
 
-	if err := kubeconfig.LoadServerKubeconfigAndMergeIn(cpCtx.Ctx, kconfig, clientset, cpCtx.Name, string(cp.Spec.Type)); err != nil {
+	if err := kubeconfig.LoadServerKubeconfigAndMergeIn(cpCtx.Ctx, kconf, clientset, cpCtx.Name, string(cp.Spec.Type)); err != nil {
 		return fmt.Errorf("error loading and merging kubeconfig: %v", err)
 
 	}
@@ -205,7 +205,7 @@ func (cpCtx *CPCtx) loadAndMergeFromServer(kconfig *api.Config) error {
 
 func (cpCtx *CPCtx) switchToHostingClusterContextAndWrite(kconf *api.Config) error {
 	if kubeconfig.IsHostingClusterContextSet(kconf) {
-		if err := kubeconfig.SwitchToHostingClusterContext(kconf, false); err != nil {
+		if err := kubeconfig.SwitchToHostingClusterContext(kconf); err != nil {
 			return err
 		}
 		if err := kubeconfig.WriteKubeconfig(cpCtx.Kubeconfig, kconf); err != nil {

--- a/cmd/kflex/ctx/ctx_test.go
+++ b/cmd/kflex/ctx/ctx_test.go
@@ -38,7 +38,9 @@ func setupMockContext(kubeconfigPath string, ctxName string) error {
 	kconf.Clusters[certs.GenerateClusterName(ctxName)] = api.NewCluster()
 	kconf.AuthInfos[certs.GenerateAuthInfoAdminName(ctxName)] = api.NewAuthInfo()
 	kconf.CurrentContext = hostingClusterContextMock
-	kubeconfig.SetHostingClusterContextPreference(kconf, nil)
+	if err := kubeconfig.SetHostingClusterContextPreference(kconf, nil); err != nil {
+		return fmt.Errorf("error setupmockcontext: %v", err)
+	}
 	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
 		return fmt.Errorf("error writing kubeconfig: %v", err)
 	}

--- a/cmd/kflex/ctx/ctx_test.go
+++ b/cmd/kflex/ctx/ctx_test.go
@@ -26,11 +26,15 @@ import (
 )
 
 var kubeconfigPath string = "./testconfig"
-var hostingClusterContextMock = "default"
+var hostingClusterContextMock = "kind-kubeflex"
 
 // Setup mock kubeconfig file with context,cluster,authinfo
 func setupMockContext(kubeconfigPath string, ctxName string) error {
 	kconf := api.NewConfig()
+	kconf.Contexts[hostingClusterContextMock] = &api.Context{
+		Cluster:  hostingClusterContextMock,
+		AuthInfo: hostingClusterContextMock,
+	}
 	kconf.Contexts[certs.GenerateContextName(ctxName)] = &api.Context{
 		Cluster:  certs.GenerateClusterName(ctxName),
 		AuthInfo: certs.GenerateAuthInfoAdminName(ctxName),

--- a/cmd/kflex/ctx/ctx_test.go
+++ b/cmd/kflex/ctx/ctx_test.go
@@ -38,7 +38,7 @@ func setupMockContext(kubeconfigPath string, ctxName string) error {
 	kconf.Clusters[certs.GenerateClusterName(ctxName)] = api.NewCluster()
 	kconf.AuthInfos[certs.GenerateAuthInfoAdminName(ctxName)] = api.NewAuthInfo()
 	kconf.CurrentContext = hostingClusterContextMock
-	if err := kubeconfig.SetHostingClusterContextPreference(kconf, nil); err != nil {
+	if err := kubeconfig.SetHostingClusterContext(kconf, nil); err != nil {
 		return fmt.Errorf("error setupmockcontext: %v", err)
 	}
 	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {

--- a/cmd/kflex/ctx/delete.go
+++ b/cmd/kflex/ctx/delete.go
@@ -58,7 +58,7 @@ func ExecuteCtxDelete(cp common.CP, ctxName string, chattyStatus bool) error {
 	}
 	if kconf.CurrentContext == ctxName {
 		fmt.Printf("prepare the switch to hosting cluster context")
-		kubeconfig.SwitchToHostingClusterContext(kconf, false)
+		kubeconfig.SwitchToHostingClusterContext(kconf)
 	}
 	if err = kubeconfig.WriteKubeconfig(cp.Kubeconfig, kconf); err != nil {
 		return fmt.Errorf("error writing kubeconfig: %v", err)

--- a/cmd/kflex/ctx/rename.go
+++ b/cmd/kflex/ctx/rename.go
@@ -86,7 +86,7 @@ func ExecuteCtxRename(cp common.CP, ctxName string, newCtxName string, toSwitch 
 		kconf.CurrentContext = newCtxName
 	} else if kconf.CurrentContext == ctxName {
 		fmt.Fprintf(os.Stdout, "switching to hosting cluster context\n")
-		kubeconfig.SwitchToHostingClusterContext(kconf, false)
+		kubeconfig.SwitchToHostingClusterContext(kconf)
 	}
 	if err = kubeconfig.WriteKubeconfig(cp.Kubeconfig, kconf); err != nil {
 		return fmt.Errorf("error writing kubeconfig: %v", err)

--- a/cmd/kflex/delete/delete.go
+++ b/cmd/kflex/delete/delete.go
@@ -65,7 +65,7 @@ func ExecuteDelete(cp common.CP, chattyStatus bool) error {
 		return fmt.Errorf("error loading kubeconfig: %v", err)
 	}
 
-	if err = kubeconfig.SwitchToHostingClusterContext(kconf, false); err != nil {
+	if err = kubeconfig.SwitchToHostingClusterContext(kconf); err != nil {
 		return fmt.Errorf("error switching to hosting cluster kubeconfig context: %v", err)
 	}
 

--- a/cmd/kflex/init/init.go
+++ b/cmd/kflex/init/init.go
@@ -111,7 +111,15 @@ func ExecuteInit(ctx context.Context, kubeconfig, version, buildDate string, dom
 	done <- true
 
 	util.PrintStatus("Setting hosting cluster preference in kubeconfig", done, &wg, chattyStatus)
-	err = kcfg.SaveHostingClusterContextPreference(kubeconfig)
+	
+	kconfig, _ := kcfg.LoadKubeconfig(kubeconfig)
+	// if err != nil {
+	// 	return fmt.Errorf("setHostingClusterContextPreference: error loading kubeconfig %s", err)
+	// }
+	kcfg.SetHostingClusterContextPreference(kconfig, nil)
+	kcfg.WriteKubeconfig(kubeconfig, kconfig)
+
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error setting hosting cluster context preference: %v\n", err)
 		os.Exit(1)

--- a/cmd/kflex/init/init.go
+++ b/cmd/kflex/init/init.go
@@ -19,7 +19,6 @@ package init
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -50,8 +49,7 @@ func Command() *cobra.Command {
 		Short: "Initialize kubeflex",
 		Long:  `Installs the default shared storage backend and the kubeflex operator`,
 		Args:  cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
-
+		RunE: func(cmd *cobra.Command, args []string) error {
 			flagset := cmd.Flags()
 			kubeconfig, _ := flagset.GetString(common.KubeconfigFlag)
 			chattyStatus, _ := flagset.GetBool(common.ChattyStatusFlag)
@@ -76,16 +74,15 @@ func Command() *cobra.Command {
 
 			if createkind {
 				if isOCP {
-					fmt.Fprintf(os.Stderr, "OpenShift cluster detected on existing context\n")
-					fmt.Fprintf(os.Stdout, "Switch to a non-OpenShift context with `kubectl config use-context <context-name>` and retry.\n")
-					os.Exit(1)
+					return fmt.Errorf("openShift cluster detected on existing context\nSwitch to a non-OpenShift context with `kubectl config use-context <context-name>` and retry")
 				}
 				cluster.CreateKindCluster(chattyStatus)
 			}
 
 			cp := common.NewCP(kubeconfig)
-			ExecuteInit(cp.Ctx, cp.Kubeconfig, common.Version, common.BuildDate, domain, strconv.Itoa(externalPort), hostContainer, chattyStatus, isOCP)
+			err = ExecuteInit(cp.Ctx, cp.Kubeconfig, common.Version, common.BuildDate, domain, strconv.Itoa(externalPort), hostContainer, chattyStatus, isOCP)
 			wg.Wait()
+			return err
 		},
 	}
 	flagset := command.Flags()
@@ -96,14 +93,13 @@ func Command() *cobra.Command {
 	return command
 }
 
-func ExecuteInit(ctx context.Context, kubeconfig, version, buildDate string, domain, externalPort, hostContainer string, chattyStatus, isOCP bool) {
+func ExecuteInit(ctx context.Context, kubeconfig, version, buildDate string, domain, externalPort, hostContainer string, chattyStatus, isOCP bool) error {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 
 	clientsetp, err := client.GetClientSet(kubeconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error getting clientset: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error getting clientset: %v", err)
 	}
 	clientset := *clientsetp
 
@@ -111,27 +107,33 @@ func ExecuteInit(ctx context.Context, kubeconfig, version, buildDate string, dom
 	done <- true
 
 	util.PrintStatus("Setting hosting cluster preference in kubeconfig", done, &wg, chattyStatus)
-	
-	kconfig, _ := kcfg.LoadKubeconfig(kubeconfig)
-	// if err != nil {
-	// 	return fmt.Errorf("setHostingClusterContextPreference: error loading kubeconfig %s", err)
-	// }
-	kcfg.SetHostingClusterContextPreference(kconfig, nil)
-	kcfg.WriteKubeconfig(kubeconfig, kconfig)
 
-
+	kconfig, err := kcfg.LoadKubeconfig(kubeconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error setting hosting cluster context preference: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error loading kubeconfig: %v", err)
+	}
+	err = kcfg.SetHostingClusterContext(kconfig, nil)
+	if err != nil {
+		return fmt.Errorf("error setting hosting cluster context: %v", err)
+	}
+	err = kcfg.WriteKubeconfig(kubeconfig, kconfig)
+	if err != nil {
+		return fmt.Errorf("error writing hosting cluster in kubeconfig: %v", err)
 	}
 	done <- true
 
 	util.PrintStatus("Ensuring kubeflex-system namespace...", done, &wg, chattyStatus)
-	ensureSystemNamespace(kubeconfig, util.SystemNamespace)
+	err = ensureSystemNamespace(kubeconfig, util.SystemNamespace)
+	if err != nil {
+		return err
+	}
 	done <- true
 
 	util.PrintStatus("Installing shared backend DB...", done, &wg, chattyStatus)
-	ensureSystemDB(ctx, isOCP)
+	err = ensureSystemDB(ctx, isOCP)
+	if err != nil {
+		return err
+	}
 	done <- true
 
 	util.PrintStatus("Waiting for shared backend DB to become ready...", done, &wg, chattyStatus)
@@ -142,7 +144,10 @@ func ExecuteInit(ctx context.Context, kubeconfig, version, buildDate string, dom
 	done <- true
 
 	util.PrintStatus("Installing kubeflex operator...", done, &wg, chattyStatus)
-	ensureKFlexOperator(ctx, version, domain, externalPort, hostContainer, isOCP)
+	err = ensureKFlexOperator(ctx, version, domain, externalPort, hostContainer, isOCP)
+	if err != nil {
+		return err
+	}
 	done <- true
 
 	util.PrintStatus("Waiting for kubeflex operator to become ready...", done, &wg, chattyStatus)
@@ -153,9 +158,10 @@ func ExecuteInit(ctx context.Context, kubeconfig, version, buildDate string, dom
 	done <- true
 
 	wg.Wait()
+	return nil
 }
 
-func ensureSystemDB(ctx context.Context, isOCP bool) {
+func ensureSystemDB(ctx context.Context, isOCP bool) error {
 	vars := []string{
 		"primary.extendedConfiguration=max_connections=1000",
 		"primary.priorityClassName=system-node-critical",
@@ -182,20 +188,19 @@ func ensureSystemDB(ctx context.Context, isOCP bool) {
 	}
 	err := helm.Init(ctx, h)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing helm: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error initializing helm: %v", err)
 	}
 
 	if !h.IsDeployed() {
 		err := h.Install()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error installing chart: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("error installing chart: %v", err)
 		}
 	}
+	return nil
 }
 
-func ensureKFlexOperator(ctx context.Context, fullVersion, domain, externalPort, hostContainer string, isOCP bool) {
+func ensureKFlexOperator(ctx context.Context, fullVersion, domain, externalPort, hostContainer string, isOCP bool) error {
 	version := util.ParseVersionNumber(fullVersion)
 	vars := []string{
 		fmt.Sprintf("version=%s", version),
@@ -215,27 +220,24 @@ func ensureKFlexOperator(ctx context.Context, fullVersion, domain, externalPort,
 	}
 	err := helm.Init(ctx, h)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing helm: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error initializing helm: %v", err)
 	}
 
 	if !h.IsDeployed() {
 		err := h.Install()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error installing chart: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("error installing chart: %v", err)
 		}
 	}
+	return nil
 }
 
-func ensureSystemNamespace(kubeconfig, namespace string) {
+func ensureSystemNamespace(kubeconfig, namespace string) error {
 	clientsetp, err := client.GetClientSet(kubeconfig)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error getting clientset: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error getting clientset: %v", err)
 	}
 	clientset := *clientsetp
-
 	_, err = clientset.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -246,9 +248,9 @@ func ensureSystemNamespace(kubeconfig, namespace string) {
 			}
 			_, err = clientset.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error creating system namespace: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("error creating system namespace: %v", err)
 			}
 		}
 	}
+	return nil
 }

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/kubestellar/kubeflex/cmd/kflex/adopt"
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
 	"github.com/kubestellar/kubeflex/cmd/kflex/create"
@@ -30,12 +31,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 )
-
-// Version injected by makefile:LDFLAGS
-var Version string
-
-// BuildDate injected by makefile:LDFLAGS
-var BuildDate string
 
 var rootCmd = &cobra.Command{
 	Use:   "kflex",
@@ -58,8 +53,12 @@ func init() {
 }
 
 // TODO - work on passing the verbosity to the logger
-
 func main() {
+	// TODO - find a way to inject it using Makefile
+	common.WarningMessage = "WARNING: current kflex version introduces BREAKING CHANGES related to kflex and your kubeconfig file which may interrupt kflex to function properly.\nSee https://github.com/kubestellar/kubeflex/blob/main/docs/users.md"
+	if common.WarningMessage != "" {
+		color.Yellow(common.WarningMessage)
+	}
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/docs/users.md
+++ b/docs/users.md
@@ -1,5 +1,54 @@
 # User's Guide
 
+## Breaking changes
+
+### v0.9.0 
+
+Kubeflex configuration is stored within Kubeconfig file. Prior this version, `kflex` put its configuration under 
+
+```yaml
+preferences:
+  extensions:
+  - extension:
+      data:
+        kflex-initial-ctx-name: kind-kubeflex  # indicates to kflex the hosting cluster context
+      metadata:
+        creationTimestamp: null
+        name: kflex-config-extension-name
+    name: kflex-config-extension-name          # indicates to kflex that this extension belongs to it
+```
+
+Starting `v0.9.0`, configuration remains within kubeconfig file but leverages `extensions:` and context-scope extension. For instance, the previous example would be translated as follow:
+
+```yaml
+extensions:                                          # change -> no longer preferences. See https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#Config
+  - extension:
+      data:
+        hosting-cluster-ctx-name: kind-kubeflex      # change -> key name "hosting-cluster-ctx-name"
+      metadata:
+        creationTimestamp: 2025-06-09T22:36:17+02:00 # creation timestamp using ISO 8601 seconds
+        name: kubeflex                               # same as below
+    name: kubeflex                                   # change -> new extension name "kubeflex"
+# ...
+# Find the context corresponding to "hosting-cluster-ctx-name" (here "kind-kubeflex")
+contexts:
+  - context:
+      cluster: kind-kubeflex
+      user: kind-kubeflex
+      # add extensions below and its information
+      extensions:
+      - extension:
+        data:
+          is-hosting-cluster-ctx: true                 # change -> key name "is-hosting-cluster-ctx" with "true"
+        metadata:
+          creationTimestamp: 2025-06-09T22:36:17+02:00 # creation timestamp using ISO 8601 seconds
+          name: kubeflex                               # same as below
+      name: kubeflex                                   # change -> new extension name "kubeflex"
+    name: kind-kubeflex
+```
+
+Proceed to change the kubeconfig file to match `v0.9.0`. At the moment, the change must be done manually until issue [#389](https://github.com/kubestellar/kubeflex/issues/389) is implemented.
+
 ## Installation
 
 [kind](https://kind.sigs.k8s.io) and [kubectl](https://kubernetes.io/docs/tasks/tools/) are

--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -41,9 +41,9 @@ const (
 
 // Internal structure of Kubeflex global extension in a Kubeconfig file
 type KubeflexExtensions struct {
-	// Must change --> BREAKING CHANGE
+	// BREAKING CHANGE
 	ConfigName string `json:"config-extension-name,omitempty"`
-	// Should change --> BREAKING CHANGE
+	// BREAKING CHANGE
 	HostingClusterContextName string `json:"hosting-cluster-ctx-name,omitempty"`
 }
 

--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"encoding/json"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	ExtensionConfigName                = "kflex-config-extension-name" // Unchanged otherwise breaking change
+	ExtensionHostingClusterContextName = "kflex-initial-ctx-name"      // Unchanged otherwise breaking change
+	ExtensionInitialContextName        = "first-context-name"
+	ExtensionControlPlaneName          = "controlplane-name"
+	ExtensionKubeflexKey               = "kubeflex"
+	ExtensionLabelManageByKubeflex     = "kubeflex.dev/is-managed"
+	ControlPlaneTypeOCMDefault         = "multicluster-controlplane"
+	ControlPlaneTypeVClusterDefault    = "my-vcluster"
+	TypeExtensionDefault               = "extensions"
+	TypeExtensionLegacy                = "preferences[].extensions"
+)
+
+// Internal structure of Kubeflex global extension in a Kubeconfig file
+type KubeflexExtensions struct {
+	// Must change --> BREAKING CHANGE
+	ConfigName string // `json:"kflex-config-extension-name,omitempty"`
+	// Should change --> BREAKING CHANGE
+	HostingClusterContextName string // `json:"kflex-initial-ctx-name,omitempty"`
+}
+
+// Internal structure of Kubeflex extension local to a context in a Kubeconfig file
+type KubeflexContextExtensions struct {
+	InitialContextName    string // `json:"first-context-name,omitempty"`
+	ControlPlaneName      string // `json:"controlplane-name,omitempty"`
+	LabelManageByKubeflex string // `json:"kubeflex.dev/is-managed,omitempty"`
+}
+
+type RuntimeKubeflexExtension struct {
+	corev1.ConfigMap
+}
+
+type RuntimeKubeflexExtensionData = map[string]string
+
+func NewRuntimeKubeflexExtension() RuntimeKubeflexExtension {
+	r := RuntimeKubeflexExtension{}
+	r.ObjectMeta = metav1.ObjectMeta{
+		Name:              ExtensionKubeflexKey,
+		CreationTimestamp: v1.NewTime(time.Now()),
+	}
+	r.Data = make(RuntimeKubeflexExtensionData)
+	return r
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) SetKubeflexConfigName(v string) {
+	runtimeKflex.Data[ExtensionConfigName] = v
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) GetKubeflexConfigName() string {
+	return runtimeKflex.Data[ExtensionConfigName]
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) SetInitialContextName(v string) {
+	runtimeKflex.Data[ExtensionInitialContextName] = v
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) GetInitialContextName() string {
+	return runtimeKflex.Data[ExtensionInitialContextName]
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) SetControlPlaneName(v string) {
+	runtimeKflex.Data[ExtensionControlPlaneName] = v
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) GetControlPlaneName() string {
+	return runtimeKflex.Data[ExtensionControlPlaneName]
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) SetLabelManageByKubeflex(v string) {
+	runtimeKflex.Data[ExtensionLabelManageByKubeflex] = v
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) GetLabelManageByKubeflex() string {
+	return runtimeKflex.Data[ExtensionLabelManageByKubeflex]
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) SetKubeflexHostingClusterContextName(v string) {
+	runtimeKflex.Data[ExtensionHostingClusterContextName] = v
+}
+
+func (runtimeKflex RuntimeKubeflexExtension) GetKubeflexHostingClusterContextName() string {
+	return runtimeKflex.Data[ExtensionHostingClusterContextName]
+}
+
+type KubeflexExtensioner interface {
+	ParseToKubeconfigExtensions() (map[string]runtime.Object, error)
+	ParseToRuntimeKubefleExtensionData() (parsed RuntimeKubeflexExtensionData, err error)
+}
+
+type KubeflexConfig struct {
+	kconf      clientcmdapi.Config
+	Extensions KubeflexExtensions // under `extensions.kubeflex`
+	// runtimeExtension RuntimeKubeflexExtension
+}
+
+func NewKubeflexConfig(kconf clientcmdapi.Config) (*KubeflexConfig, error) {
+	kflexConfig := KubeflexConfig{kconf: kconf, Extensions: KubeflexExtensions{}}
+	if runtimeObj, ok := kconf.Extensions[ExtensionKubeflexKey]; ok {
+		runtimeExtension := RuntimeKubeflexExtension{}
+		err := ConvertRuntimeObjectToRuntimeKubeflexExtension(runtimeObj, runtimeExtension)
+		if err != nil {
+			return nil, err
+		}
+		kflexConfig.Extensions.ConfigName = runtimeExtension.GetKubeflexConfigName()
+		kflexConfig.Extensions.HostingClusterContextName = runtimeExtension.GetKubeflexHostingClusterContextName()
+	}
+	return &kflexConfig, nil
+}
+
+// func NewKubeflexContextConfig() *KubeflexContextConfig {
+// 	return
+// }
+
+// Unmarshal runtime.Object into RuntimeKubeflexExtension
+func ConvertRuntimeObjectToRuntimeKubeflexExtension(data runtime.Object, receiver RuntimeKubeflexExtension) error {
+	dataJson, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(dataJson, &receiver)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Parse KubeflexExtensions into RuntimeKubeflexExtensionData
+func (kflexConfig KubeflexConfig) ParseToRuntimeKubefleExtensionData() (parsed RuntimeKubeflexExtensionData, err error) {
+	data, err := json.Marshal(kflexConfig.Extensions)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, &parsed)
+	if err != nil {
+		return nil, err
+	}
+	return parsed, err
+}
+
+// Parse KubeflexExtensions into Kubeconfig Extensions
+func (kflexConfig KubeflexConfig) ParseToKubeconfigExtensions() (map[string]runtime.Object, error) {
+	runtimeExtensionData, err := kflexConfig.ParseToRuntimeKubefleExtensionData()
+	if err != nil {
+		return nil, err
+	}
+	runtimeExtension := NewRuntimeKubeflexExtension()
+	runtimeExtension.Data = runtimeExtensionData
+	return map[string]runtime.Object{ExtensionKubeflexKey: &runtimeExtension}, nil
+}
+
+type KubeflexContextConfig struct {
+	kconf             clientcmdapi.Config
+	Context           string
+	ContextExtensions KubeflexContextExtensions
+}

--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -69,6 +69,7 @@ func NewRuntimeKubeflexExtension() *RuntimeKubeflexExtension {
 	r.ObjectMeta = metav1.ObjectMeta{
 		Name:              ExtensionKubeflexKey,
 		CreationTimestamp: metav1.NewTime(time.Now()),
+		Namespace:         "",
 	}
 	r.Data = make(RuntimeKubeflexExtensionData)
 	return r
@@ -77,6 +78,7 @@ func NewRuntimeKubeflexExtension() *RuntimeKubeflexExtension {
 type KubeflexConfiger interface {
 	ConvertExtensionsToRuntimeExtension(receiver *RuntimeKubeflexExtension) error
 	ConvertRuntimeExtensionToExtensions(producer *RuntimeKubeflexExtension) error
+	ParseToKubeconfigExtensions() (map[string]runtime.Object, error)
 }
 
 type kubeflexConfig[T KubeflexExtensions | KubeflexContextExtensions] struct {
@@ -112,6 +114,15 @@ func (kflexConfig *kubeflexConfig[T]) ConvertRuntimeExtensionToExtensions(produc
 		return fmt.Errorf("json unmarshal of producer data failed: %v", err)
 	}
 	return nil
+}
+
+func (kflexConfig *kubeflexConfig[T]) ParseToKubeconfigExtensions() (map[string]runtime.Object, error) {
+	r := NewRuntimeKubeflexExtension()
+	err := kflexConfig.ConvertExtensionsToRuntimeExtension(r)
+	if err != nil {
+		return nil, fmt.Errorf("error while parsing kubeflex to kubeconfig extensions: %v", err)
+	}
+	return map[string]runtime.Object{ExtensionKubeflexKey: r}, err
 }
 
 type KubeflexConfig struct {

--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -28,14 +28,11 @@ import (
 )
 
 const (
-	ExtensionConfigName                = "config-extension-name"    // BREAKING CHANGE
 	ExtensionHostingClusterContextName = "hosting-cluster-ctx-name" // BREAKING CHANGE
 	ExtensionContextsIsHostingCluster  = "is-hosting-cluster-ctx"   // BREAKING CHANGE
 	ExtensionInitialContextName        = "first-ctx-name"
 	ExtensionControlPlaneName          = "controlplane-name"
 	ExtensionKubeflexKey               = "kubeflex"
-	ControlPlaneTypeOCMDefault         = "multicluster-controlplane"
-	ControlPlaneTypeVClusterDefault    = "my-vcluster"
 	TypeExtensionDefault               = "extensions"
 	TypeExtensionLegacy                = "preferences[].extensions"
 )
@@ -43,13 +40,11 @@ const (
 // Internal structure of Kubeflex global extension in a Kubeconfig file
 type KubeflexExtensions struct {
 	// BREAKING CHANGE
-	ConfigName string `json:"config-extension-name,omitempty"`
-	// BREAKING CHANGE
 	HostingClusterContextName string `json:"hosting-cluster-ctx-name,omitempty"`
 }
 
 func (kflexExtensions KubeflexExtensions) String() string {
-	return fmt.Sprintf("KubeflexExtensions: ConfigName=%s; HostingClusterContextName=%s;", kflexExtensions.ConfigName, kflexExtensions.HostingClusterContextName)
+	return fmt.Sprintf("KubeflexExtensions: HostingClusterContextName=%s;", kflexExtensions.HostingClusterContextName)
 }
 
 // Internal structure of Kubeflex extension local to a context in a Kubeconfig file
@@ -60,7 +55,7 @@ type KubeflexContextExtensions struct {
 }
 
 func (kflexContextExtensions KubeflexContextExtensions) String() string {
-	return fmt.Sprintf("KubeflexContextExtensions: InitialContextName=%s; ControlPlaneName=%s;", kflexContextExtensions.InitialContextName, kflexContextExtensions.ControlPlaneName)
+	return fmt.Sprintf("KubeflexContextExtensions: InitialContextName=%s; ControlPlaneName=%s; IsHostingClusterContext=%s;", kflexContextExtensions.InitialContextName, kflexContextExtensions.ControlPlaneName, kflexContextExtensions.IsHostingClusterContext)
 }
 
 type RuntimeKubeflexExtension = corev1.ConfigMap

--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -30,6 +30,7 @@ import (
 const (
 	ExtensionConfigName                = "config-extension-name"    // BREAKING CHANGE
 	ExtensionHostingClusterContextName = "hosting-cluster-ctx-name" // BREAKING CHANGE
+	ExtensionContextsIsHostingCluster  = "is-hosting-cluster-ctx"   // BREAKING CHANGE
 	ExtensionInitialContextName        = "first-ctx-name"
 	ExtensionControlPlaneName          = "controlplane-name"
 	ExtensionKubeflexKey               = "kubeflex"
@@ -53,8 +54,9 @@ func (kflexExtensions KubeflexExtensions) String() string {
 
 // Internal structure of Kubeflex extension local to a context in a Kubeconfig file
 type KubeflexContextExtensions struct {
-	InitialContextName string `json:"first-ctx-name,omitempty"`
-	ControlPlaneName   string `json:"controlplane-name,omitempty"`
+	InitialContextName      string `json:"first-ctx-name,omitempty"`
+	ControlPlaneName        string `json:"controlplane-name,omitempty"`
+	IsHostingClusterContext string `json:"is-hosting-cluster-ctx,omitempty"`
 }
 
 func (kflexContextExtensions KubeflexContextExtensions) String() string {
@@ -145,13 +147,13 @@ func NewKubeflexConfig(kconf clientcmdapi.Config) (*KubeflexConfig, error) {
 }
 
 type KubeflexContextConfig struct {
-	*kubeflexConfig[KubeflexExtensions]
+	*kubeflexConfig[KubeflexContextExtensions]
 	ContextName string
 }
 
 // New kubeflex config local to a context in a kubeconfig
 func NewKubeflexContextConfig(kconf clientcmdapi.Config, contextName string) (*KubeflexContextConfig, error) {
-	kflexConfig := newKflexConfig[KubeflexExtensions](kconf)
+	kflexConfig := newKflexConfig[KubeflexContextExtensions](kconf)
 	ctx, hasCtx := kconf.Contexts[contextName]
 	if runtimeObj, ok := ctx.Extensions[ExtensionKubeflexKey]; hasCtx && ok {
 		runtimeExtension := &RuntimeKubeflexExtension{}

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -7,8 +7,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-const configName = "mockConfigName"
-const configNameExistent = "mockConfigNameLoaded"
 const hostingClusterContextName = "kind-kubeflex"
 const hostingClusterContextNameExistent = "kind-legacy-kubeflex"
 
@@ -21,12 +19,10 @@ func SetupMockKubeflexConfig(receiver **KubeflexConfig) (err error) {
 		if err != nil {
 			return err
 		}
-		(*receiver).Extensions.ConfigName = configName
 		(*receiver).Extensions.HostingClusterContextName = hostingClusterContextName
 	} else {
 		// Define extensions.kubeflex mock values
 		fmt.Println("setup mock with existent values")
-		(*receiver).Extensions.ConfigName = configNameExistent
 		(*receiver).Extensions.HostingClusterContextName = hostingClusterContextNameExistent
 	}
 	return nil
@@ -39,11 +35,8 @@ func TestKubeflexConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to setup kubeflex config")
 	}
-	if kflexConfig.Extensions.ConfigName != configName {
-		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s'", configName)
-	}
 	if kflexConfig.Extensions.HostingClusterContextName != hostingClusterContextName {
-		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s'", hostingClusterContextName)
+		t.Errorf("fail to setup kubeflex config as HostingClusterContextName is not '%s'", hostingClusterContextName)
 	}
 }
 
@@ -57,11 +50,8 @@ func TestKubeflexConfigWithExistentValues(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to setup kubeflex config")
 	}
-	if kflexConfig.Extensions.ConfigName != configNameExistent {
-		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s'", configNameExistent)
-	}
 	if kflexConfig.Extensions.HostingClusterContextName != hostingClusterContextNameExistent {
-		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s'", hostingClusterContextNameExistent)
+		t.Errorf("fail to setup kubeflex config as HostingClusterContextName is not '%s'", hostingClusterContextNameExistent)
 	}
 }
 
@@ -79,9 +69,6 @@ func TestKubeflexConfigWrittenAsKubeConfig(t *testing.T) {
 	}
 	fmt.Printf("runtimeKflex metadata: %v\n", runtimeKflex.ObjectMeta)
 	fmt.Printf("runtimeKflex data: %v\n", runtimeKflex.Data)
-	if v, ok := runtimeKflex.Data[ExtensionConfigName]; !ok || v != configNameExistent {
-		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s': value is %s", configNameExistent, v)
-	}
 	if v, ok := runtimeKflex.Data[ExtensionHostingClusterContextName]; !ok || v != hostingClusterContextNameExistent {
 		t.Errorf("fail to setup kubeflex config as HostingClusterContextName is not '%s': value is %s", hostingClusterContextNameExistent, v)
 	}

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -1,0 +1,88 @@
+package kubeconfig
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+const configName = "mockConfigName"
+const configNameExistent = "mockConfigNameLoaded"
+const hostingClusterContextName = "kind-kubeflex"
+const hostingClusterContextNameExistent = "kind-legacy-kubeflex"
+
+// Setup mock values to KubeflexConfig
+func SetupMockKubeflexConfig(receiver **KubeflexConfig) (err error) {
+	kconf := api.NewConfig()
+	if *receiver == nil {
+		fmt.Println("setup mock with new values")
+		*receiver, err = NewKubeflexConfig(*kconf)
+		if err != nil {
+			return err
+		}
+		(*receiver).Extensions.ConfigName = configName
+		(*receiver).Extensions.HostingClusterContextName = hostingClusterContextName
+	} else {
+		// Define extensions.kubeflex mock values
+		fmt.Println("setup mock with existent values")
+		(*receiver).Extensions.ConfigName = configNameExistent
+		(*receiver).Extensions.HostingClusterContextName = hostingClusterContextNameExistent
+	}
+	return nil
+}
+
+// Test KubeflexConfig has correct mock values
+func TestKubeflexConfig(t *testing.T) {
+	var kflexConfig *KubeflexConfig
+	err := SetupMockKubeflexConfig(&kflexConfig)
+	if err != nil {
+		t.Errorf("fail to setup kubeflex config")
+	}
+	if kflexConfig.Extensions.ConfigName != configName {
+		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s'", configName)
+	}
+	if kflexConfig.Extensions.HostingClusterContextName != hostingClusterContextName {
+		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s'", hostingClusterContextName)
+	}
+}
+
+// Test KubeflexConfig has correct mock values if it is not null
+func TestKubeflexConfigWithExistentValues(t *testing.T) {
+	kflexConfig, err := NewKubeflexConfig(*api.NewConfig())
+	if err != nil {
+		t.Errorf("fail to create new kubeflex config")
+	}
+	err = SetupMockKubeflexConfig(&kflexConfig)
+	if err != nil {
+		t.Errorf("fail to setup kubeflex config")
+	}
+	if kflexConfig.Extensions.ConfigName != configNameExistent {
+		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s'", configNameExistent)
+	}
+	if kflexConfig.Extensions.HostingClusterContextName != hostingClusterContextNameExistent {
+		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s'", hostingClusterContextNameExistent)
+	}
+}
+
+// Test conversion of KubeflexConfig to Kubeconfig extensions data
+func TestKubeflexConfigWrittenAsKubeConfig(t *testing.T) {
+	kflexConfig, _ := NewKubeflexConfig(*api.NewConfig())
+	err := SetupMockKubeflexConfig(&kflexConfig)
+	if err != nil {
+		t.Errorf("fail to setup")
+	}
+	fmt.Printf("kflexConfig: extensions: %v\n", kflexConfig.Extensions)
+	runtimeKflex := NewRuntimeKubeflexExtension()
+	if err = kflexConfig.ConvertExtensionsToRuntimeExtension(runtimeKflex); err != nil {
+		t.Errorf("fail to convert extensions to runtime extension")
+	}
+	fmt.Printf("runtimeKflex metadata: %v\n", runtimeKflex.ObjectMeta)
+	fmt.Printf("runtimeKflex data: %v\n", runtimeKflex.Data)
+	if v, ok := runtimeKflex.Data[ExtensionConfigName]; !ok || v != configNameExistent {
+		t.Errorf("fail to setup kubeflex config as ConfigName is not '%s': value is %s", configNameExistent, v)
+	}
+	if v, ok := runtimeKflex.Data[ExtensionHostingClusterContextName]; !ok || v != hostingClusterContextNameExistent {
+		t.Errorf("fail to setup kubeflex config as HostingClusterContextName is not '%s': value is %s", hostingClusterContextNameExistent, v)
+	}
+}

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -37,6 +37,11 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+const (
+	ControlPlaneTypeOCMDefault      = "multicluster-controlplane"
+	ControlPlaneTypeVClusterDefault = "my-vcluster"
+)
+
 func adjustConfigKeys(kconf *clientcmdapi.Config, cpName, controlPlaneType string) {
 	switch controlPlaneType {
 	case string(tenancyv1alpha1.ControlPlaneTypeOCM):

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -264,7 +264,7 @@ func SetHostingClusterContext(kconf *clientcmdapi.Config, userSuppliedContext *s
 	if userSuppliedContext != nil {
 		hostingContext = *userSuppliedContext
 	}
-	kflexConfig.Extensions.ConfigName = hostingContext
+	kflexConfig.Extensions.HostingClusterContextName = hostingContext
 	kconf.Extensions, err = kflexConfig.ParseToKubeconfigExtensions()
 	if err != nil {
 		return fmt.Errorf("error while setting hosting cluster context to extensions: %v", err)

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -37,16 +37,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-const (
-	ExtensionConfigName                = "kflex-config-extension-name" // Unchanged otherwise breaking change
-	ExtensionHostingClusterContextName = "kflex-initial-ctx-name"      // Unchanged otherwise breaking change
-	ExtensionInitialContextName        = "first-context-name"
-	ExtensionControlPlaneName          = "controlplane-name"
-	ExtensionKubeflexKey               = "kubeflex"
-	ExtensionLabelManageByKubeflex     = "kubeflex.dev/is-managed"
-	ControlPlaneTypeOCMDefault         = "multicluster-controlplane"
-	ControlPlaneTypeVClusterDefault    = "my-vcluster"
-)
 
 func unMarshallCM(obj runtime.Object) (*corev1.ConfigMap, error) {
 	jsonData, err := json.Marshal(obj)

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -98,7 +98,7 @@ func merge(base, target *clientcmdapi.Config) error {
 	}
 
 	if !IsHostingClusterContextSet(base) {
-		err := SetHostingClusterContextPreference(base, nil)
+		err := SetHostingClusterContext(base, nil)
 		if err != nil {
 			return fmt.Errorf("error on ExecuteCtx: %v", err)
 		}
@@ -254,24 +254,8 @@ func RenameKey(m interface{}, oldKey string, newKey string) {
 	}
 }
 
-// DISCUSSION: shouldn't we keep our functions as much low-level as possible?
-// Rather than having SaveHostingClusterContextPreference as a function
-// Shouldn't we use SetHostingClusterContextPreference and WriteKubeconfig
-// whenever it is required? It seem clearer to only have a single WRITE function
-// instead of SAVE function that embeds WRITE... (personal observation)
-func SaveHostingClusterContextPreference(kubeconfig string) error {
-	// TODO replace context parameter
-	kconfig, err := LoadKubeconfig(kubeconfig)
-	if err != nil {
-		return fmt.Errorf("setHostingClusterContextPreference: error loading kubeconfig %s", err)
-	}
-	SetHostingClusterContextPreference(kconfig, nil)
-	// TODO replace context parameter
-	return WriteKubeconfig(kubeconfig, kconfig)
-}
-
 // Sets hosting cluster context to current context if userSuppliedContext is nil, otherwise set to userSuppliedContext
-func SetHostingClusterContextPreference(config *clientcmdapi.Config, userSuppliedContext *string) error {
+func SetHostingClusterContext(config *clientcmdapi.Config, userSuppliedContext *string) error {
 	kflexConfig, err := NewKubeflexConfig(*config)
 	if err != nil {
 		return fmt.Errorf("error while setting hosting cluster context to extensions: %v", err)

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -97,7 +97,7 @@ func merge(base, target *clientcmdapi.Config) error {
 		base.Contexts[k] = v
 	}
 
-	if !IsHostingClusterContextPreferenceSet(base) {
+	if !IsHostingClusterContextSet(base) {
 		SetHostingClusterContextPreference(base, nil)
 	}
 
@@ -172,14 +172,12 @@ func GetHostingClusterContext(config *clientcmdapi.Config) (string, error) {
 	return kflexConfig.Extensions.HostingClusterContextName, nil
 }
 
-func IsHostingClusterContextPreferenceSet(config *clientcmdapi.Config) bool {
-	if config.Preferences.Extensions != nil {
-		_, ok := config.Preferences.Extensions[ExtensionConfigName]
-		if ok {
-			return true
-		}
+func IsHostingClusterContextSet(config *clientcmdapi.Config) bool {
+	kflexConfig, err := NewKubeflexConfig(*config)
+	if err != nil {
+		return false
 	}
-	return false
+	return kflexConfig.Extensions.HostingClusterContextName != ""
 }
 
 // List all contexts
@@ -302,7 +300,7 @@ func SwitchContext(config *clientcmdapi.Config, cpName string) error {
 
 // Switch to hosting cluster context
 func SwitchToHostingClusterContext(config *clientcmdapi.Config, removeExtension bool) error {
-	if !IsHostingClusterContextPreferenceSet(config) {
+	if !IsHostingClusterContextSet(config) {
 		return fmt.Errorf("hosting cluster preference context not set")
 	}
 


### PR DESCRIPTION
## Summary

The implementation of `Preferences` used to be *on-the-fly* by using `corev1.ConfigMap` as "k8s.io/client-go/tools/clientcmd/api" requires `runtime.Object` type for `Extension`.

In our new implementation, a new file `extensions.go` is created where structs are defined. This allow us Static typing and check at compilation time, reducing likelihood of errors.

## BREAKING CHANGES

Within the code, breaking changes are indicated through comment `// BREAKING CHANGE`

```go
const (
	ExtensionConfigName                = "config-extension-name"    // BREAKING CHANGE
	ExtensionHostingClusterContextName = "hosting-cluster-ctx-name" // BREAKING CHANGE
```

Those values have changed. Also, perhaps some of these values are now useless. In fact, all kubeflex metadata are stored under `kubeflex` key (ie. `extensions.kubeflex`) therefore `ExtensionConfigName` seems irrelevant.

Functions defined in `pkg/kubeconfig/kubeconfig.go` are no longer looking up to `preferences.extensions` within a Kubeconfig. Thereby, any clients/end-users using kflex version prior this PR has their Kubeconfig populated by `Preferences`. Once this PR merge to `kubestellar/kubeflex`, metadata stored under `Preferences` are ignored (hence become irrelevant) and new metadata will be inserted under `extensions` and `contexts[].extensions`. Breaking changes are to be expected for the end user.

Old way:
```yaml
preferences:
  extensions:
  - extension:
      data:
        kflex-initial-ctx-name: kind-kubeflex    # key=ExtensionHostingClusterContextName
      metadata:
        creationTimestamp: null
        name: kflex-config-extension-name        # value=ExtensionConfigName
    name: kflex-config-extension-name            # value=ExtensionConfigName
```

New way:
```yaml
# global
extensions:
- extension:
    data:
      hosting-cluster-ctx-name: kind-kubeflex    # key=ExtensionHostingClusterContextName
    metadata:
      creationTimestamp: null
      name: kubeflex                             # value=ExtensionKubeflexKey
  name: kubeflex                                 # value=ExtensionKubeflexKey
# ...
# context-scope
contexts:
- name: kind-kubeflex
  context:
    cluster: kind-kubeflex
    user: kind-kubeflex
  extensions:
  - extension:
      data:
        first-ctx-name: kind-kubeflex            # key=ExtensionInitialContextName
        is-hosting-cluster-ctx: true             # key=ExtensionContextsIsHostingCluster
      metadata:
        creationTimestamp: null
        name: kubeflex
    name: kubeflex
```

To alleviate those breaking changes, a follow up PR is to be considerated. The creation of a command `kflex config` seems ideal where subcommands interact with Kubeconfig. For instance, to help the transition to this breaking changes, we can imagine:
- `kflex config tidy` to migrate/clean-up a kubeconfig to adapt with kubeflex latest changes.

## Related issue(s)

Fixes #385 
