### PR TITLE
✨ Add `kflex config set-hosting`

### DIFF
--- a/cmd/kflex/config/config.go
+++ b/cmd/kflex/config/config.go
@@ -22,7 +22,7 @@ import (
 
 func Command() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "config",
+		Use:   "config COMMAND",
 		Short: "Configure kubeflex",
 		Long:  `Configure settings of kubeflex set within a kubeconfig file`,
 		Args:  cobra.ExactArgs(1),

--- a/cmd/kflex/config/config.go
+++ b/cmd/kflex/config/config.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "config",
+		Short: "Configure kubeflex",
+		Long:  `Configure settings of kubeflex set within a kubeconfig file`,
+		Args:  cobra.ExactArgs(1),
+	}
+	command.AddCommand(CommandSetHostingClusterCtx())
+	return command
+}

--- a/cmd/kflex/config/config_test.go
+++ b/cmd/kflex/config/config_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config

--- a/cmd/kflex/config/set_hosting_cluster_ctx.go
+++ b/cmd/kflex/config/set_hosting_cluster_ctx.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+	"github.com/spf13/cobra"
+)
+
+func CommandSetHostingClusterCtx() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "set-hosting",
+		Short: "Set hosting cluster context",
+		Long:  `Set hosting cluster context name of kubeflex within kubeconfig file`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flagset := cmd.Flags()
+			kubeconfigFile, err := flagset.GetString(common.KubeconfigFlag)
+			if err != nil {
+				return fmt.Errorf("error while parsing --kubeconfig: %v", err)
+			}
+			return ExecuteSetHostingClusterCtx(kubeconfigFile, args[0])
+		},
+	}
+	return command
+}
+
+// Set hosting cluster context name
+func ExecuteSetHostingClusterCtx(kubeconfigFile string, ctxName string) error {
+	kconf, err := kubeconfig.LoadKubeconfig(kubeconfigFile)
+	if err != nil {
+		return fmt.Errorf("error while executing set hosting cluster ctx: %v", err)
+	}
+	fmt.Printf("setting hosting cluster context name to '%s' in %s", ctxName, kubeconfigFile)
+	err = kubeconfig.SetHostingClusterContext(kconf, &ctxName)
+	if err != nil {
+		return fmt.Errorf("error while executing set hosting cluster ctx: %v", err)
+	}
+	err = kubeconfig.WriteKubeconfig(kubeconfigFile, kconf)
+	if err != nil {
+		return fmt.Errorf("error while executing set hosting cluster ctx: %v", err)
+	}
+	return nil
+}

--- a/cmd/kflex/config/set_hosting_cluster_ctx.go
+++ b/cmd/kflex/config/set_hosting_cluster_ctx.go
@@ -26,11 +26,12 @@ import (
 
 func CommandSetHostingClusterCtx() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "set-hosting",
+		Use:   "set-hosting CTX_NAME",
 		Short: "Set hosting cluster context",
 		Long:  `Set hosting cluster context name of kubeflex within kubeconfig file`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			flagset := cmd.Flags()
 			kubeconfigFile, err := flagset.GetString(common.KubeconfigFlag)
 			if err != nil {
@@ -48,7 +49,7 @@ func ExecuteSetHostingClusterCtx(kubeconfigFile string, ctxName string) error {
 	if err != nil {
 		return fmt.Errorf("error while executing set hosting cluster ctx: %v", err)
 	}
-	fmt.Printf("setting hosting cluster context name to '%s' in %s", ctxName, kubeconfigFile)
+	fmt.Printf("setting hosting cluster context name to '%s' in %s\n", ctxName, kubeconfigFile)
 	err = kubeconfig.SetHostingClusterContext(kconf, &ctxName)
 	if err != nil {
 		return fmt.Errorf("error while executing set hosting cluster ctx: %v", err)

--- a/cmd/kflex/config/set_hosting_cluster_ctx_test.go
+++ b/cmd/kflex/config/set_hosting_cluster_ctx_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config

--- a/cmd/kflex/config/set_hosting_cluster_ctx_test.go
+++ b/cmd/kflex/config/set_hosting_cluster_ctx_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The KubeStellar Authors.
+Copyright 2025 The KubeStellar Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,3 +15,79 @@ limitations under the License.
 */
 
 package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/kubestellar/kubeflex/pkg/certs"
+	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+var kubeconfigPath string = "./testconfig"
+var hostingClusterContextMock = "kind-kubeflex"
+
+// Setup mock kubeconfig file with context,cluster,authinfo
+func setupKubeconfig(kubeconfigPath string, ctxName string) error {
+	kconf := api.NewConfig()
+	// hosting cluster context entry
+	kconf.Contexts[hostingClusterContextMock] = &api.Context{
+		Cluster:  hostingClusterContextMock,
+		AuthInfo: hostingClusterContextMock,
+	}
+	kconf.Clusters[hostingClusterContextMock] = api.NewCluster()
+	kconf.AuthInfos[hostingClusterContextMock] = api.NewAuthInfo()
+	// ctxName entry
+	kconf.Contexts[certs.GenerateContextName(ctxName)] = &api.Context{
+		Cluster:  certs.GenerateClusterName(ctxName),
+		AuthInfo: certs.GenerateAuthInfoAdminName(ctxName),
+	}
+	kconf.Clusters[certs.GenerateClusterName(ctxName)] = api.NewCluster()
+	kconf.AuthInfos[certs.GenerateAuthInfoAdminName(ctxName)] = api.NewAuthInfo()
+	kconf.CurrentContext = hostingClusterContextMock
+	fmt.Printf("kconf: %v\n", kconf)
+	if err := kubeconfig.SetHostingClusterContext(kconf, nil); err != nil {
+		return fmt.Errorf("error setupmockcontext: %v", err)
+	}
+	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
+		return fmt.Errorf("error writing kubeconfig: %v", err)
+	}
+	return nil
+}
+
+// Delete mock kubeconfig file
+func teardown(kubeconfigPath string) error {
+	return os.Remove(kubeconfigPath)
+}
+
+func TestSetHostingClusterCtx_ValidKubeconfig(t *testing.T) {
+	ctxName := "cp1"
+	setupKubeconfig(kubeconfigPath, ctxName)
+	defer teardown(kubeconfigPath)
+	// Execute command - change hosting cluster ctx name to $ctxName
+	err := ExecuteSetHostingClusterCtx(kubeconfigPath, ctxName)
+	if err != nil {
+		t.Errorf("execute set hosting cluster ctx command failed: %v", err)
+	}
+	// Checking values
+	kconf, err := kubeconfig.LoadKubeconfig(kubeconfigPath)
+	if err != nil {
+		t.Errorf("error loading kubeconfig: %v", err)
+	}
+	kflexConfig, err := kubeconfig.NewKubeflexConfig(*kconf)
+	if err != nil {
+		t.Errorf("error creating kflexConfig: %v", err)
+	}
+	kflexContextConfig, err := kubeconfig.NewKubeflexContextConfig(*kconf, ctxName)
+	if err != nil {
+		t.Errorf("error creating kflexContextConfig: %v", err)
+	}
+	if kflexConfig.Extensions.HostingClusterContextName != ctxName {
+		t.Errorf("hosting cluster context name must be changed from '%s' to '%s', not '%s'", hostingClusterContextMock, ctxName, kflexConfig.Extensions.HostingClusterContextName)
+	}
+	if kflexContextConfig.Extensions.IsHostingClusterContext != "true" {
+		t.Errorf("hosting cluster context must indicates to be hosting cluster using 'true' not '%s'", kflexContextConfig.Extensions.IsHostingClusterContext)
+	}
+}

--- a/cmd/kflex/ctx/ctx_test.go
+++ b/cmd/kflex/ctx/ctx_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package ctx
 
 import (
-	"fmt"
 	"os"
+	"testing"
 
 	"github.com/kubestellar/kubeflex/pkg/certs"
 	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
@@ -29,7 +29,7 @@ var kubeconfigPath string = "./testconfig"
 var hostingClusterContextMock = "kind-kubeflex"
 
 // Setup mock kubeconfig file with context,cluster,authinfo
-func setupMockContext(kubeconfigPath string, ctxName string) error {
+func setupMockContext(t *testing.T, kubeconfigPath string, ctxName string) {
 	kconf := api.NewConfig()
 	kconf.Contexts[hostingClusterContextMock] = &api.Context{
 		Cluster:  hostingClusterContextMock,
@@ -43,15 +43,16 @@ func setupMockContext(kubeconfigPath string, ctxName string) error {
 	kconf.AuthInfos[certs.GenerateAuthInfoAdminName(ctxName)] = api.NewAuthInfo()
 	kconf.CurrentContext = hostingClusterContextMock
 	if err := kubeconfig.SetHostingClusterContext(kconf, nil); err != nil {
-		return fmt.Errorf("error setupmockcontext: %v", err)
+		t.Fatalf("error setupmockcontext: %v", err)
 	}
 	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
-		return fmt.Errorf("error writing kubeconfig: %v", err)
+		t.Fatalf("error writing kubeconfig: %v", err)
 	}
-	return nil
 }
 
 // Delete mock kubeconfig file
-func teardown(kubeconfigPath string) error {
-	return os.Remove(kubeconfigPath)
+func teardown(t *testing.T, kubeconfigPath string) {
+	if err := os.Remove(kubeconfigPath); err != nil {
+		t.Fatalf("failed to teardown: %v", err)
+	}
 }

--- a/cmd/kflex/ctx/delete_test.go
+++ b/cmd/kflex/ctx/delete_test.go
@@ -28,8 +28,8 @@ import (
 // from the kubeconfig
 func TestDeleteOk(t *testing.T) {
 	ctxName := "cptobedeleted"
-	setupMockContext(kubeconfigPath, ctxName)
-	defer teardown(kubeconfigPath)
+	setupMockContext(t, kubeconfigPath, ctxName)
+	defer teardown(t, kubeconfigPath)
 
 	// Start test
 	cp := common.NewCP(kubeconfigPath, common.WithName(ctxName))
@@ -61,8 +61,8 @@ func TestDeleteOk(t *testing.T) {
 func TestDeleteNonExistentContext(t *testing.T) {
 	ctxName := "cptobedeleted"
 	noneCtxName := "none"
-	setupMockContext(kubeconfigPath, ctxName)
-	defer teardown(kubeconfigPath)
+	setupMockContext(t, kubeconfigPath, ctxName)
+	defer teardown(t, kubeconfigPath)
 
 	// Start test
 	cp := common.NewCP(kubeconfigPath, common.WithName(ctxName))

--- a/cmd/kflex/ctx/rename_test.go
+++ b/cmd/kflex/ctx/rename_test.go
@@ -29,8 +29,8 @@ func TestRenameOk(t *testing.T) {
 	// Mock data
 	ctxName := "testcp"
 	expected := "testcp-renamed"
-	setupMockContext(kubeconfigPath, ctxName)
-	defer teardown(kubeconfigPath)
+	setupMockContext(t, kubeconfigPath, ctxName)
+	defer teardown(t, kubeconfigPath)
 
 	// Start test
 	cp := common.NewCP(kubeconfigPath, common.WithName(ctxName))
@@ -63,8 +63,8 @@ func TestRenameThenSwitchOk(t *testing.T) {
 	// Mock data
 	ctxName := "testcp"
 	expected := "testcp-renamed"
-	setupMockContext(kubeconfigPath, ctxName)
-	defer teardown(kubeconfigPath)
+	setupMockContext(t, kubeconfigPath, ctxName)
+	defer teardown(t, kubeconfigPath)
 
 	// Start test
 	cp := common.NewCP(kubeconfigPath, common.WithName(ctxName))
@@ -95,8 +95,8 @@ func TestRenameNonExistentContext(t *testing.T) {
 	// Mock data
 	ctxName := "nonexistent"
 	expected := "testcp-renamed"
-	setupMockContext(kubeconfigPath, "random")
-	defer teardown(kubeconfigPath)
+	setupMockContext(t, kubeconfigPath, "random")
+	defer teardown(t, kubeconfigPath)
 	// Start test
 	cp := common.NewCP(kubeconfigPath, common.WithName(ctxName))
 	err := ExecuteCtxRename(cp, ctxName, expected, false)

--- a/cmd/kflex/main.go
+++ b/cmd/kflex/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/kubestellar/kubeflex/cmd/kflex/adopt"
 	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/kubestellar/kubeflex/cmd/kflex/config"
 	"github.com/kubestellar/kubeflex/cmd/kflex/create"
 	kflexCtx "github.com/kubestellar/kubeflex/cmd/kflex/ctx"
 	"github.com/kubestellar/kubeflex/cmd/kflex/delete"
@@ -50,6 +51,7 @@ func init() {
 	rootCmd.AddCommand(delete.Command())
 	rootCmd.AddCommand(create.Command())
 	rootCmd.AddCommand(list.Command())
+	rootCmd.AddCommand(config.Command())
 }
 
 // TODO - work on passing the verbosity to the logger

--- a/docs/users.md
+++ b/docs/users.md
@@ -47,7 +47,17 @@ contexts:
     name: kind-kubeflex
 ```
 
-Proceed to change the kubeconfig file to match `v0.9.0`. At the moment, the change must be done manually until issue [#389](https://github.com/kubestellar/kubeflex/issues/389) is implemented.
+Proceed to change the kubeconfig file to match `v0.9.0`, as follow:
+
+1. Set new hosting cluster context name running:
+```bash
+kflex config set-hosting $ctx_name
+```
+where `$ctx_name` represents the desired hosting context name 
+
+2. Delete `preferences:` related to **kubeflex** by editing your kubeconfig file manually.
+
+At the moment, the change must be done manually until issue [#389](https://github.com/kubestellar/kubeflex/issues/389) is implemented.
 
 ## Installation
 

--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -147,10 +147,13 @@ type KubeflexContextConfig struct {
 }
 
 // New kubeflex config local to a context in a kubeconfig
-func NewKubeflexContextConfig(kconf clientcmdapi.Config, contextName string) (*KubeflexContextConfig, error) {
+func NewKubeflexContextConfig(kconf clientcmdapi.Config, ctxName string) (*KubeflexContextConfig, error) {
 	kflexConfig := newKflexConfig[KubeflexContextExtensions](kconf)
-	ctx, hasCtx := kconf.Contexts[contextName]
-	if runtimeObj, ok := ctx.Extensions[ExtensionKubeflexKey]; hasCtx && ok {
+	ctx, hasCtx := kconf.Contexts[ctxName]
+	if !hasCtx {
+		return nil, fmt.Errorf("context '%s' must exist within kubeconfig", ctxName)
+	}
+	if runtimeObj, ok := ctx.Extensions[ExtensionKubeflexKey]; ok {
 		runtimeExtension := &RuntimeKubeflexExtension{}
 		if err := ConvertRuntimeObjectToRuntimeExtension(runtimeObj, runtimeExtension); err != nil {
 			return nil, err
@@ -159,7 +162,7 @@ func NewKubeflexContextConfig(kconf clientcmdapi.Config, contextName string) (*K
 			return nil, err
 		}
 	}
-	return &KubeflexContextConfig{kubeflexConfig: kflexConfig, ContextName: contextName}, nil
+	return &KubeflexContextConfig{kubeflexConfig: kflexConfig, ContextName: ctxName}, nil
 }
 
 // Unmarshal runtime.Object into RuntimeKubeflexExtension

--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -171,9 +171,7 @@ func ConvertRuntimeObjectToRuntimeExtension(data runtime.Object, receiver *Runti
 	if err != nil {
 		return err
 	}
-	fmt.Printf("dataJson: %s\n", dataJson)
 	err = json.Unmarshal(dataJson, &receiver)
-	fmt.Printf("unmarshal: %v\n", *receiver)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -270,16 +270,18 @@ func SetHostingClusterContext(kconf *clientcmdapi.Config, ctxName *string) error
 	if ctxName != nil {
 		hostingContext = *ctxName
 	}
-	kflexConfig.Extensions.HostingClusterContextName = hostingContext
-	kconf.Extensions, err = kflexConfig.ParseToKubeconfigExtensions()
-	if err != nil {
-		return fmt.Errorf("error while setting hosting cluster context to extensions: %v", err)
-	}
 	kflexContextConfig, err := NewKubeflexContextConfig(*kconf, hostingContext)
 	if err != nil {
 		return fmt.Errorf("error while setting hosting cluster context to context extensions: %v", err)
 	}
+	// Setting hosting cluster context values
+	kflexConfig.Extensions.HostingClusterContextName = hostingContext
 	kflexContextConfig.Extensions.IsHostingClusterContext = strconv.FormatBool(true)
+	// Updating kubeconfig extensions with values
+	kconf.Extensions, err = kflexConfig.ParseToKubeconfigExtensions()
+	if err != nil {
+		return fmt.Errorf("error while setting hosting cluster context to extensions: %v", err)
+	}
 	kconf.Contexts[hostingContext].Extensions, err = kflexContextConfig.ParseToKubeconfigExtensions()
 	if err != nil {
 		return fmt.Errorf("error while setting hosting cluster context to context extensions: %v", err)


### PR DESCRIPTION
## Summary

Introducing `kflex config` command to interact with kubeconfig/kubeflex configuration.

This PR introduces the first config feature `set-hosting` to set/change the value of hosting cluster context name.

**Usage:** `kflex config set-hosting $mycp` 

Set hosting cluster context name to `$mycp` value

## Related issue(s)

Fixes #387 
