### PR TITLE
✨: add k3s package for reconciler

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - "release-*"
-
+      - "lxf/**"
 jobs:
   ci-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - "release-*"
 jobs:
   check:

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches:
       - main
+      - "lxf/**"
   push:
     branches:
       - main
+      - "lxf/**"
     tags:
       - 'v*'
 

--- a/api/v1alpha1/controlplane_types.go
+++ b/api/v1alpha1/controlplane_types.go
@@ -98,7 +98,7 @@ const (
 	BackendDBTypeDedicated BackendDBType = "dedicated"
 )
 
-// +kubebuilder:validation:Enum=k8s;ocm;vcluster;host;external;k3s;
+// +kubebuilder:validation:Enum=k8s;ocm;vcluster;host;external;k3s
 type ControlPlaneType string
 
 const (

--- a/pkg/reconcilers/k3s/README.md
+++ b/pkg/reconcilers/k3s/README.md
@@ -1,0 +1,11 @@
+# k3s 
+
+## Code design
+
+`pkg/k3s` package adopts a **component driven** design which implies the k3s code to be splitted into files name after k3s components:
+
+- `apiserver.go` k3s API server
+- `reconciler.go` k3s reconciler which expose `Reconcile` function that reconcile all k3s components
+- `service.go` k3s service
+
+Each Go file contains all methods related to its component.

--- a/pkg/reconcilers/k3s/apiserver.go
+++ b/pkg/reconcilers/k3s/apiserver.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k3s
+
+import (
+	"context"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// K3s API server
+type APIServer struct {
+	*shared.BaseReconciler
+}
+
+// Init API server object to apply on kubernetes server
+// TODO: to implement
+func NewAPIServer() (_ metav1.Object, err error) {
+	return &appsv1.StatefulSet{}, nil
+}
+
+// Reconcile API server
+// implements ControlPlaneReconciler
+// TODO: to implement
+func (r *APIServer) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
+	return r.BaseReconciler.Reconcile(ctx, hcp)
+}

--- a/pkg/reconcilers/k3s/reconciler.go
+++ b/pkg/reconcilers/k3s/reconciler.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k3s
+
+import (
+	"context"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// K3sReconciler embeds all k3s components
+type K3sReconciler struct {
+	*Service               // k3s service
+	*APIServer             // k3s api server
+	*shared.BaseReconciler // shared base controller
+}
+
+// Init new K3sReconciler
+// create a BaseReconciler datastruct that is shared to Service and APIServer.
+// Both Service and APIServer interact on the same reference of BaseReconciler
+func New(cl client.Client, scheme *runtime.Scheme, version string, clientSet *kubernetes.Clientset, dynamicClient *dynamic.DynamicClient, eventRecorder record.EventRecorder) *K3sReconciler {
+	br := shared.BaseReconciler{
+		Client:        cl,
+		Scheme:        scheme,
+		ClientSet:     clientSet,
+		DynamicClient: dynamicClient,
+		EventRecorder: eventRecorder,
+	}
+	return &K3sReconciler{
+		BaseReconciler: &br,
+		Service:        &Service{&br},
+		APIServer:      &APIServer{&br},
+	}
+}
+
+// Reconcile K3s control plane
+// implements ControlPlaneReconciler
+// TODO: to implement
+func (r *K3sReconciler) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
+	// Idempotent
+	return r.BaseReconciler.Reconcile(ctx, hcp)
+}

--- a/pkg/reconcilers/k3s/service.go
+++ b/pkg/reconcilers/k3s/service.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k3s
+
+import (
+	"context"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
+	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// K3s service
+type Service struct {
+	*shared.BaseReconciler
+}
+
+// Reconcile a service
+// implements ControlPlaneReconciler
+// TODO: to implement
+func (svc *Service) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
+	return svc.BaseReconciler.Reconcile(ctx, hcp)
+}

--- a/pkg/reconcilers/k8s/deployment.go
+++ b/pkg/reconcilers/k8s/deployment.go
@@ -51,14 +51,17 @@ func (r *K8sReconciler) ReconcileAPIServerDeployment(ctx context.Context, hcp *t
 	err := r.Client.Get(context.TODO(), client.ObjectKeyFromObject(deployment), deployment, &client.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// Init API server deployment object
 			dbName := util.ReplaceNotAllowedCharsInDBName(hcp.Name)
 			deployment, err = r.generateAPIServerDeployment(namespace, dbName, isOCP)
 			if err != nil {
 				return err
 			}
+			// Set owner reference of the API server deployment object
 			if err := controllerutil.SetControllerReference(hcp, deployment, r.Scheme); err != nil {
 				return err
 			}
+			// Create API server deployment resource on kubernetes cluster
 			if err = r.Client.Create(context.TODO(), deployment, &client.CreateOptions{}); err != nil {
 				return err
 			}

--- a/pkg/reconcilers/k8s/reconciler.go
+++ b/pkg/reconcilers/k8s/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
 	"github.com/kubestellar/kubeflex/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clog "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/pkg/certs"
 )
 

--- a/pkg/reconcilers/shared/route.go
+++ b/pkg/reconcilers/shared/route.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kubestellar/kubeflex/pkg/util"
 )
 
+
 func (r *BaseReconciler) ReconcileAPIServerRoute(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane, svcName string, svcPort int, domain string) error {
 	namespace := util.GenerateNamespaceFromControlPlaneName(hcp.Name)
 

--- a/pkg/util/pg.go
+++ b/pkg/util/pg.go
@@ -40,6 +40,7 @@ func DropDatabase(ctx context.Context, cpName string, crClient client.Client) er
 	return nil
 }
 
+// TODO: change func signature to be more explicit 
 func ReplaceNotAllowedCharsInDBName(name string) string {
 	return strings.ReplaceAll(name, "-", "_")
 }


### PR DESCRIPTION
## Summary

Add skeleton for k3s reconciler package.

A different code design has been chosen to implement k3s (!= vcluster or k8s).

Instead of defining multiple reconcile functions depending of a resource (ie. ReconcileNamespace, ReconcileService), a `ControlPlaneReconciler` interface is now defined. (NOTE: I wonder if it should be named `KubeflexReconciler` instead...) Based on that interface, k3s declares concrete types representing kubernetes components `Service` `APIServer` `Reconciler`. All these concrete types implement `ControlPlaneReconciler`. As a result, `K3sReconciler` is defined as follow

```go
// New code design
type K3sReconciler struct {
	*Service               // k3s service
	*APIServer             // k3s api server
	*shared.BaseReconciler // shared base controller
}
```

instead of 

```go
// Old way
type K3sReconciler struct {
        *shared.BaseReconciler 
}

type K8sReconciler struct {
	*shared.BaseReconciler
}

```

which allows us to do

```go
  var r K3sReconciler
  // ...
  r.Service.Reconcile(ctx, hcp) // instead of r.BaseReconciler.ReconcileService
```

IMO, this produce a cleaner and standardized codebase. More importantly, reduce coupling of a function to the codebase. See code change for more info.

## Related issue(s)

Fixes #417
