### PR TITLE
🐛Lxf/431: solve k3s server pod error

### DIFF
--- a/pkg/reconcilers/k3s/apiserver.go
+++ b/pkg/reconcilers/k3s/apiserver.go
@@ -25,15 +25,21 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	clog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// k3s constants
 const ServerName = "k3s-server"
 const ServerDockerImage = "rancher/k3s"
+const StorageName = "data-k3s-server"
+const StorageClassName = "standard" // kind default storage class name which is rancher/local-storage (same as k3s but different name)
+const StoragePath = "/data"
 
 // K3s API server
 // NOTE: k3s is a single binary containing apiserver, etcd, controller-manager... therefore `Server` refers to all components
@@ -46,6 +52,7 @@ func serverLabels() map[string]string {
 	return map[string]string{
 		"controller.kubeflex.dev/type":         string(tenancyv1alpha1.ControlPlaneTypeK3s),
 		"controller.kubeflex.dev/service-name": ServiceName,
+		"controller.kubeflex.dev/pvc-name":     StorageName,
 	}
 }
 
@@ -87,9 +94,36 @@ func NewServer(cpName string) (*appsv1.StatefulSet, error) {
 							Ports: []v1.ContainerPort{
 								{ContainerPort: shared.SecurePort},
 							},
+							VolumeMounts: []v1.VolumeMount{
+								// VolumeMount k3s data
+								{
+									Name:      StorageName,
+									MountPath: StoragePath,
+									ReadOnly:  false,
+								},
+							},
+							SecurityContext: &v1.SecurityContext{
+								// Required by $ServerDockerImage
+								Privileged: ptr.To(true),
+								// Required to write filesystem as privileged
+								ReadOnlyRootFilesystem: ptr.To(false),
+								// Additional security
+								SeccompProfile: &v1.SeccompProfile{
+									Type: v1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
 						},
 					},
 					Volumes: []v1.Volume{
+						// Volume k3s data
+						{
+							Name: StorageName,
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									ClaimName: StorageName,
+								},
+							},
+						},
 						// Volume kubernetes certificates
 						{
 							Name: "k8s-certs",
@@ -116,17 +150,81 @@ func NewServer(cpName string) (*appsv1.StatefulSet, error) {
 	}, nil
 }
 
+// apiVersion: v1
+// kind: PersistentVolumeClaim
+// metadata:
+//
+//	name: local-path-pvc
+//	namespace: k3stest
+//
+// spec:
+//
+//	accessModes:
+//	  - ReadWriteOnce
+//	storageClassName: standard
+//	volumeMode: Filesystem
+//	resources:
+//	  requests:
+//	    storage: 2Gi
+func NewPVC(cpName string) (*v1.PersistentVolumeClaim, error) {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      StorageName,
+			Namespace: GenerateSystemNamespaceName(cpName),
+			Labels:    serverLabels(),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("2Gi"),
+				},
+			},
+			StorageClassName: ptr.To(StorageClassName),
+		},
+	}, nil
+}
+
 // Reconcile k3s server
 // implements ControlPlaneReconciler
 // TODO to implement
 func (r *Server) Reconcile(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) (ctrl.Result, error) {
 	log := clog.FromContext(ctx)
+	// Get k3s pvc that is required for k3s server to run
+	k3sPVCObject := &v1.PersistentVolumeClaim{}
+	k3sPVCObjectKey := client.ObjectKey{Namespace: GenerateSystemNamespaceName(hcp.Name), Name: StorageName}
+	log.Info("k3s:server.go:Reconcile:", "k3sPVCObjectKey", k3sPVCObjectKey)
+	err := r.Client.Get(ctx, k3sPVCObjectKey, k3sPVCObject)
+	if err != nil {
+		log.Error(err, "k3s:server.go:Reconcile:r.Client.Get pvc failed")
+		r.BaseReconciler.UpdateStatusForSyncingError(ctx, hcp, err) // TODO: to change
+		if apierrors.IsNotFound(err) {
+			log.Error(err, "k3s:server.go:Reconcile:pvc is not found error")
+			log.Info("k3s:server.go:Reconcile:call NewServer() on k3sServerObject")
+			// Generate new k3s server
+			k3sPVCObject, _ = NewPVC(hcp.Name)
+			log.Info("k3s:server.go:Reconcile:call SetControllerReference on pvc")
+			// Set owner reference of the API server object
+			if err := controllerutil.SetControllerReference(hcp, k3sPVCObject, r.Scheme); err != nil {
+				log.Error(err, "k3s:server.go:Reconcile:SetControllerReference on pvc failed")
+				return ctrl.Result{}, err
+			}
+			// Create the k3s server
+			log.Info("k3s:server.go:Reconcile:call r.Client.Create on", "k3sPVCObject", k3sPVCObject)
+			if err = r.Client.Create(ctx, k3sPVCObject); err != nil {
+				log.Error(err, "k3s:server.go:Reconcile:r.Client.Create pvc failed")
+				return ctrl.Result{RequeueAfter: 10}, err
+			}
+		}
+		return ctrl.Result{}, err
+	}
 	// Get k3s server from hosting cluster and stored it in k3sServerObject
-
 	k3sServerObject := &appsv1.StatefulSet{}
 	k3sServerObjectKey := client.ObjectKey{Namespace: GenerateSystemNamespaceName(hcp.Name), Name: ServerName}
 	log.Info("k3s:server.go:Reconcile:", "k3sServerObjectKey", k3sServerObjectKey)
-	err := r.Client.Get(ctx, k3sServerObjectKey, k3sServerObject)
+	err = r.Client.Get(ctx, k3sServerObjectKey, k3sServerObject)
 	if err != nil {
 		log.Error(err, "k3s:server.go:Reconcile:r.Client.Get failed")
 		r.BaseReconciler.UpdateStatusForSyncingError(ctx, hcp, err) // TODO: to change

--- a/test/dev/k3stest.yaml
+++ b/test/dev/k3stest.yaml
@@ -1,0 +1,49 @@
+###
+# Test: simple up-and-running k3s server
+# Minimal configuration to deploy k3s server as Pod
+#
+# Works when:
+# - priviledge=true + seccompProfile=Unconfined + readOnlyRootFilesystem=false
+###
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-path-pvc
+  namespace: k3stest
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: k3s-server
+  namespace: k3stest
+spec:
+  containers:
+  - name: k3s-server
+    image: "rancher/k3s:v1.30.13-k3s1"
+    args:
+      - server
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+      readOnlyRootFilesystem: false
+      privileged: true
+    volumeMounts:
+    - name: data
+      mountPath: /data
+    ports:
+    - containerPort: 80
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: local-path-pvc
+


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When k3s-server is deployed, the following error arise

`time="2025-06-24T14:56:41Z" level=info msg="Waiting to retrieve agent configuration; server is not ready: mkdir /etc/rancher: read-only file system"`

To solve it, security context has been added at the container level to enable filesystem to be writeable by root. In addition, container must be ran privileged as shown on the official documentation: https://docs.k3s.io/advanced#using-docker-as-the-container-runtime

Now, `k3s-server` is running once deployed

```shell
└─[$] <git:(lxf/main*)> k get pods -n k3stest
NAME         READY   STATUS    RESTARTS   AGE
k3s-server   1/1     Running   0          81s
```
and its logs

```log
...
│ I0624 14:59:31.293305      58 event.go:389] "Event occurred" object="kube-system/traefik" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="UpdatedLoadBalancer" message="Updated LoadBalancer with new IPs: [10.244.0 │
│ I0624 14:59:35.810943      58 replica_set.go:676] "Finished syncing" kind="ReplicaSet" key="kube-system/metrics-server-8677f8544d" duration="32.708922ms"                                                                              │
│ I0624 14:59:35.811035      58 replica_set.go:676] "Finished syncing" kind="ReplicaSet" key="kube-system/metrics-server-8677f8544d" duration="37.75µs"                                                                                  │
│ I0624 14:59:35.851842      58 handler.go:286] Adding GroupVersion metrics.k8s.io v1beta1 to ResourceManager                                                                                                                            │
│ I0624 14:59:41.556662      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="ingressroutetcps.traefik.io"                                                                                      │
│ I0624 14:59:41.556896      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="middlewares.traefik.io"                                                                                           │
│ I0624 14:59:41.556989      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="tlsoptions.traefik.containo.us"                                                                                   │
│ I0624 14:59:41.557014      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="tlsstores.traefik.io"                                                                                             │
│ I0624 14:59:41.557084      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="middlewaretcps.traefik.io"                                                                                        │
│ I0624 14:59:41.557120      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="ingressroutes.traefik.containo.us"                                                                                │
│ I0624 14:59:41.557148      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="serverstransports.traefik.containo.us"                                                                            │
│ I0624 14:59:41.557191      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="ingressroutetcps.traefik.containo.us"                                                                             │
│ I0624 14:59:41.557217      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="serverstransporttcps.traefik.io"                                                                                  │
│ I0624 14:59:41.557253      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="middlewaretcps.traefik.containo.us"                                                                               │
│ I0624 14:59:41.557305      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="middlewares.traefik.containo.us"                                                                                  │
│ I0624 14:59:41.557421      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="tlsstores.traefik.containo.us"                                                                                    │
│ I0624 14:59:41.557452      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="ingressrouteudps.traefik.containo.us"                                                                             │
│ I0624 14:59:41.557512      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="traefikservices.traefik.containo.us"                                                                              │
│ I0624 14:59:41.557535      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="tlsoptions.traefik.io"                                                                                            │
│ I0624 14:59:41.557576      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="traefikservices.traefik.io"                                                                                       │
│ I0624 14:59:41.557642      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="serverstransports.traefik.io"                                                                                     │
│ I0624 14:59:41.557673      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="ingressroutes.traefik.io"                                                                                         │
│ I0624 14:59:41.557756      58 resource_quota_monitor.go:224] "QuotaMonitor created object count evaluator" resource="ingressrouteudps.traefik.io"                                                                                      │
│ I0624 14:59:41.559731      58 shared_informer.go:313] Waiting for caches to sync for resource quota                                                                                                                                    │
│ I0624 14:59:42.068015      58 shared_informer.go:320] Caches are synced for resource quota                                                                                                                                             │
│ I0624 14:59:42.097360      58 shared_informer.go:313] Waiting for caches to sync for garbage collector                                                                                                                                 │
│ I0624 14:59:42.102106      58 shared_informer.go:320] Caches are synced for garbage collector
```

## Related issue(s)

Fixes #431 
