### PR TITLE
✨ feature : add control plane name to kubeflex extension data

### DIFF
--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -126,6 +126,8 @@ func AssignControlPlaneToContext(kconf *clientcmdapi.Config, cpName string, ctxN
 		if err != nil {
 			return fmt.Errorf("error while assigning control plane to context: %v", err)
 		}
+		// Step 3: Assign to the context kubeflex extension data the key ExtensionControlPlaneName const and controlplane name as value
+		kflexConfig.Extensions.ControlPlaneName = cpName
 		if parsed, err = kflexConfig.ParseToKubeconfigExtensions(); err != nil {
 			return fmt.Errorf("error while assigning control plane to context: %v", err)
 		}

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,57 @@
+package kubeconfig
+
+import (
+	"testing"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// Setup and teardown helpers
+func setupTestKubeconfigWithContext(ctxName string) *api.Config {
+	kconf := api.NewConfig()
+	kconf.Contexts[ctxName] = &api.Context{
+		Cluster:  "test-cluster",
+		AuthInfo: "test-user",
+	}
+	return kconf
+}
+
+func teardownTestKubeconfig(kconf *api.Config, ctxName string) {
+	delete(kconf.Contexts, ctxName)
+}
+
+func TestAssignControlPlaneToContext_Positive(t *testing.T) {
+	ctxName := "test-context"
+	cpName := "test-controlplane"
+	kconf := setupTestKubeconfigWithContext(ctxName)
+	defer teardownTestKubeconfig(kconf, ctxName)
+
+	err := AssignControlPlaneToContext(kconf, cpName, ctxName)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	ext, ok := kconf.Contexts[ctxName].Extensions[ExtensionKubeflexKey]
+	if !ok {
+		t.Fatalf("expected kubeflex extension to be set in context")
+	}
+
+	runtimeExt, ok := ext.(*RuntimeKubeflexExtension)
+	if !ok {
+		t.Fatalf("expected extension to be of type *RuntimeKubeflexExtension")
+	}
+
+	if got := runtimeExt.Data[ExtensionControlPlaneName]; got != cpName {
+		t.Errorf("expected controlplane-name to be '%s', got '%s'", cpName, got)
+	}
+}
+
+func TestAssignControlPlaneToContext_Negative_ContextDoesNotExist(t *testing.T) {
+	ctxName := "nonexistent-context"
+	cpName := "test-controlplane"
+	kconf := api.NewConfig()
+
+	err := AssignControlPlaneToContext(kconf, cpName, ctxName)
+	if err == nil {
+		t.Fatalf("expected error for nonexistent context, got nil")
+	}
+} 

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -30,14 +30,19 @@ func TestAssignControlPlaneToContext_Positive(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
-	ext, ok := kconf.Contexts[ctxName].Extensions[ExtensionKubeflexKey]
+	_, ok := kconf.Contexts[ctxName].Extensions[ExtensionKubeflexKey]
 	if !ok {
 		t.Fatalf("expected kubeflex extension to be set in context")
 	}
 
-	runtimeExt, ok := ext.(*RuntimeKubeflexExtension)
-	if !ok {
-		t.Fatalf("expected extension to be of type *RuntimeKubeflexExtension")
+	kflexConfig, err := NewKubeflexContextConfig(*kconf, ctxName)
+	if err != nil {
+		t.Fatalf("expected no error creating kubeflex context config, got: %v", err)
+	}
+	runtimeExt := NewRuntimeKubeflexExtension()
+	err = kflexConfig.ConvertExtensionsToRuntimeExtension(runtimeExt)
+	if err != nil {
+		t.Fatalf("expected no error converting extensions to runtime extension, got: %v", err)
 	}
 
 	if got := runtimeExt.Data[ExtensionControlPlaneName]; got != cpName {


### PR DESCRIPTION
## Summary
The update to the `AssignControlPlaneToContext` function in the pkg/kubeconfig package ensures that the function now correctly stores the control plane name as an extension within the context's kubeflex extension data. This resolves the previously missing step where the control plane name was not being assigned to the extension. A new kubeconfig_test.go file is created to provide unit tests.

## Related issue(s)
Fixes #435 
