### PR TITLE
🌱 test: update vcluster e2e test for changes in AssignControlPlaneToContext

### DIFF
--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -126,6 +126,8 @@ func AssignControlPlaneToContext(kconf *clientcmdapi.Config, cpName string, ctxN
 		if err != nil {
 			return fmt.Errorf("error while assigning control plane to context: %v", err)
 		}
+		// Step 3: Assign to the context kubeflex extension data the key ExtensionControlPlaneName const and controlplane name as value
+		kflexConfig.Extensions.ControlPlaneName = cpName
 		if parsed, err = kflexConfig.ParseToKubeconfigExtensions(); err != nil {
 			return fmt.Errorf("error while assigning control plane to context: %v", err)
 		}

--- a/pkg/kubeconfig/kubeconfig_test.go
+++ b/pkg/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,57 @@
+package kubeconfig
+
+import (
+	"testing"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// Setup and teardown helpers
+func setupTestKubeconfigWithContext(ctxName string) *api.Config {
+	kconf := api.NewConfig()
+	kconf.Contexts[ctxName] = &api.Context{
+		Cluster:  "test-cluster",
+		AuthInfo: "test-user",
+	}
+	return kconf
+}
+
+func teardownTestKubeconfig(kconf *api.Config, ctxName string) {
+	delete(kconf.Contexts, ctxName)
+}
+
+func TestAssignControlPlaneToContext_Positive(t *testing.T) {
+	ctxName := "test-context"
+	cpName := "test-controlplane"
+	kconf := setupTestKubeconfigWithContext(ctxName)
+	defer teardownTestKubeconfig(kconf, ctxName)
+
+	err := AssignControlPlaneToContext(kconf, cpName, ctxName)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	ext, ok := kconf.Contexts[ctxName].Extensions[ExtensionKubeflexKey]
+	if !ok {
+		t.Fatalf("expected kubeflex extension to be set in context")
+	}
+
+	runtimeExt, ok := ext.(*RuntimeKubeflexExtension)
+	if !ok {
+		t.Fatalf("expected extension to be of type *RuntimeKubeflexExtension")
+	}
+
+	if got := runtimeExt.Data[ExtensionControlPlaneName]; got != cpName {
+		t.Errorf("expected controlplane-name to be '%s', got '%s'", cpName, got)
+	}
+}
+
+func TestAssignControlPlaneToContext_Negative_ContextDoesNotExist(t *testing.T) {
+	ctxName := "nonexistent-context"
+	cpName := "test-controlplane"
+	kconf := api.NewConfig()
+
+	err := AssignControlPlaneToContext(kconf, cpName, ctxName)
+	if err == nil {
+		t.Fatalf("expected error for nonexistent context, got nil")
+	}
+} 

--- a/test/e2e/manage-type-vcluster.sh
+++ b/test/e2e/manage-type-vcluster.sh
@@ -23,52 +23,56 @@ source "${SRC_DIR}/setup-shell.sh"
 : -------------------------------------------------------------------------
 : Create a ControlPlane of type vcluster
 :
-./bin/kflex create myhellocp --type vcluster --chatty-status=false
+./bin/kflex create cp2 --type vcluster --chatty-status=false
 
 :
 : -------------------------------------------------------------------------
 : Verify that the kubeconfig has the correct extensions structure
 : with controlplane-name set in the context
 :
-echo "Verifying kubeconfig extensions for control plane myhellocp..."
+echo "Verifying kubeconfig extensions for control plane cp2..."
 
-# Check that the context exists
-if ! kubectl config view --raw | grep -q "name: myhellocp"; then
-    echo "ERROR: Context myhellocp not found in kubeconfig"
+context_name="cp2"
+cp_name="cp2"
+
+# Extract the controlplane-name from kubeconfig extensions using yq
+actual_cp_name=$(kubectl config view -o=yaml | yq -r '.contexts[] | select(.name == "'$context_name'") | .context.extensions[] | select(.name == "kubeflex") | .extension.data["controlplane-name"] // ""')
+
+if [ -z "$actual_cp_name" ]; then
+    echo "ERROR: Context $context_name not found or does not have kubeflex extension with controlplane-name"
+    echo "Available contexts:"
+    kubectl config view -o=yaml | yq -r '.contexts[].name'
     exit 1
 fi
 
-# Check that the context has the kubeflex extension with controlplane-name
-if ! kubectl config view --raw | grep -A 50 "name: myhellocp" | grep -A 20 "extensions:" | grep -q "controlplane-name: myhellocp"; then
-    echo "ERROR: Context myhellocp does not have controlplane-name extension set to myhellocp"
-    echo "Showing the myhellocp context section:"
-    kubectl config view --raw | grep -A 30 "name: myhellocp"
+if [ "$actual_cp_name" != "$cp_name" ]; then
+    echo "ERROR: Expected controlplane-name '$cp_name', but found '$actual_cp_name'"
     exit 1
 fi
 
-echo "SUCCESS: Kubeconfig extensions verified for control plane myhellocp"
+echo "SUCCESS: Kubeconfig extensions verified for control plane cp2"
 
 :
 : -------------------------------------------------------------------------
-: Wait for the running component of ControlPlane myhellocp to be ready/completed
+: Wait for the running component of ControlPlane cp2 to be ready/completed
 :
-kubectl --context kind-kubeflex -n myhellocp-system wait --for=jsonpath='{.status.availableReplicas}'=1 statefulset/vcluster --timeout=120s
-kubectl --context kind-kubeflex -n myhellocp-system wait --for=condition=Complete job/update-cluster-info --timeout=120s
+kubectl --context kind-kubeflex -n cp2-system wait --for=jsonpath='{.status.availableReplicas}'=1 statefulset/vcluster --timeout=120s
+kubectl --context kind-kubeflex -n cp2-system wait --for=condition=Complete job/update-cluster-info --timeout=120s
 
 :
 : -------------------------------------------------------------------------
-: Create a Deployment in ControlPlane myhellocp, then wait for the Deployment
+: Create a Deployment in ControlPlane cp2, then wait for the Deployment
 : to become available
 :
-kubectl --context myhellocp create deployment my-nginx --image public.ecr.aws/nginx/nginx:1.26.3
+kubectl --context cp2 create deployment my-nginx --image public.ecr.aws/nginx/nginx:1.26.3
 
-kubectl --context myhellocp wait --for=condition=Available deploy/my-nginx --timeout=120s
+kubectl --context cp2 wait --for=condition=Available deploy/my-nginx --timeout=120s
 
 :
 : -------------------------------------------------------------------------
-: Delete ControlPlane myhellocp
+: Delete ControlPlane cp2
 :
-./bin/kflex delete myhellocp --chatty-status=false
+./bin/kflex delete cp2 --chatty-status=false
 
 :
 : -------------------------------------------------------------------------

--- a/test/e2e/manage-type-vcluster.sh
+++ b/test/e2e/manage-type-vcluster.sh
@@ -16,33 +16,59 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 
+SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source "${SRC_DIR}/setup-shell.sh"
+
 :
 : -------------------------------------------------------------------------
 : Create a ControlPlane of type vcluster
 :
-./bin/kflex create cp2 --type vcluster --chatty-status=false
+./bin/kflex create myhellocp --type vcluster --chatty-status=false
 
 :
 : -------------------------------------------------------------------------
-: Wait for the running component of ControlPlane cp2 to be ready/completed
+: Verify that the kubeconfig has the correct extensions structure
+: with controlplane-name set in the context
 :
-kubectl --context kind-kubeflex -n cp2-system wait --for=jsonpath='{.status.availableReplicas}'=1 statefulset/vcluster --timeout=120s
-kubectl --context kind-kubeflex -n cp2-system wait --for=condition=Complete job/update-cluster-info --timeout=120s
+echo "Verifying kubeconfig extensions for control plane myhellocp..."
+
+# Check that the context exists
+if ! kubectl config view --raw | grep -q "name: myhellocp"; then
+    echo "ERROR: Context myhellocp not found in kubeconfig"
+    exit 1
+fi
+
+# Check that the context has the kubeflex extension with controlplane-name
+if ! kubectl config view --raw | grep -A 50 "name: myhellocp" | grep -A 20 "extensions:" | grep -q "controlplane-name: myhellocp"; then
+    echo "ERROR: Context myhellocp does not have controlplane-name extension set to myhellocp"
+    echo "Showing the myhellocp context section:"
+    kubectl config view --raw | grep -A 30 "name: myhellocp"
+    exit 1
+fi
+
+echo "SUCCESS: Kubeconfig extensions verified for control plane myhellocp"
 
 :
 : -------------------------------------------------------------------------
-: Create a Deployment in ControlPlane cp2, then wait for the Deployment
+: Wait for the running component of ControlPlane myhellocp to be ready/completed
+:
+kubectl --context kind-kubeflex -n myhellocp-system wait --for=jsonpath='{.status.availableReplicas}'=1 statefulset/vcluster --timeout=120s
+kubectl --context kind-kubeflex -n myhellocp-system wait --for=condition=Complete job/update-cluster-info --timeout=120s
+
+:
+: -------------------------------------------------------------------------
+: Create a Deployment in ControlPlane myhellocp, then wait for the Deployment
 : to become available
 :
-kubectl --context cp2 create deployment my-nginx --image public.ecr.aws/nginx/nginx:1.26.3
+kubectl --context myhellocp create deployment my-nginx --image public.ecr.aws/nginx/nginx:1.26.3
 
-kubectl --context cp2 wait --for=condition=Available deploy/my-nginx --timeout=120s
+kubectl --context myhellocp wait --for=condition=Available deploy/my-nginx --timeout=120s
 
 :
 : -------------------------------------------------------------------------
-: Delete ControlPlane cp2
+: Delete ControlPlane myhellocp
 :
-./bin/kflex delete cp2 --chatty-status=false
+./bin/kflex delete myhellocp --chatty-status=false
 
 :
 : -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Ensures that `kflex create myhellocp --type=vcluster` assigns controlplane name within context-scope.
Update `test/e2e/manage-type-vcluster.sh`.

## Related issue(s)
Fixes #437
