### PR TITLE
✨ Add guard for kflex ctx delete: confirmation for non-KubeFlex contexts

### DIFF
--- a/cmd/kflex/ctx/ctx_test.go
+++ b/cmd/kflex/ctx/ctx_test.go
@@ -45,6 +45,32 @@ func setupMockContext(t *testing.T, kubeconfigPath string, ctxName string) {
 	if err := kubeconfig.SetHostingClusterContext(kconf, nil); err != nil {
 		t.Fatalf("error setupmockcontext: %v", err)
 	}
+	// Add KubeFlex extension to the test context to make it appear as managed by KubeFlex
+	if err := kubeconfig.AssignControlPlaneToContext(kconf, ctxName, certs.GenerateContextName(ctxName)); err != nil {
+		t.Fatalf("error assigning control plane to context: %v", err)
+	}
+	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
+		t.Fatalf("error writing kubeconfig: %v", err)
+	}
+}
+
+// Setup mock kubeconfig file with context,cluster,authinfo without KubeFlex extension
+func setupMockContextWithoutKubeflex(t *testing.T, kubeconfigPath string, ctxName string) {
+	kconf := api.NewConfig()
+	kconf.Contexts[hostingClusterContextMock] = &api.Context{
+		Cluster:  hostingClusterContextMock,
+		AuthInfo: hostingClusterContextMock,
+	}
+	kconf.Contexts[certs.GenerateContextName(ctxName)] = &api.Context{
+		Cluster:  certs.GenerateClusterName(ctxName),
+		AuthInfo: certs.GenerateAuthInfoAdminName(ctxName),
+	}
+	kconf.Clusters[certs.GenerateClusterName(ctxName)] = api.NewCluster()
+	kconf.AuthInfos[certs.GenerateAuthInfoAdminName(ctxName)] = api.NewAuthInfo()
+	kconf.CurrentContext = hostingClusterContextMock
+	if err := kubeconfig.SetHostingClusterContext(kconf, nil); err != nil {
+		t.Fatalf("error setupmockcontext: %v", err)
+	}
 	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
 		t.Fatalf("error writing kubeconfig: %v", err)
 	}

--- a/cmd/kflex/ctx/delete_test.go
+++ b/cmd/kflex/ctx/delete_test.go
@@ -33,7 +33,7 @@ func TestDeleteOk(t *testing.T) {
 
 	// Start test
 	cp := common.NewCP(kubeconfigPath, common.WithName(ctxName))
-	err := ExecuteCtxDelete(cp, ctxName, false, false)
+	err := ExecuteCtxDelete(cp, ctxName, false)
 	if err != nil {
 		t.Errorf("failed to run 'kflex ctx delete %s': %v", ctxName, err)
 	}
@@ -71,7 +71,7 @@ func TestDeleteNonExistentContext(t *testing.T) {
 		t.Errorf("error loading kubeconfig: %v", err)
 	}
 	nCtx := len(kconf.Contexts)
-	err = ExecuteCtxDelete(cp, noneCtxName, false, false)
+	err = ExecuteCtxDelete(cp, noneCtxName, false)
 	if err == nil {
 		t.Errorf("expect ExecuteCtxDelete to fail but it succeeded")
 	}
@@ -88,7 +88,7 @@ func TestDeleteNonKubeflexContext(t *testing.T) {
 
 	// Start test
 	cp := common.NewCP(kubeconfigPath, common.WithName(ctxName))
-	err := ExecuteCtxDelete(cp, ctxName, false, true)
+	err := ExecuteCtxDelete(cp, ctxName, false, WithForce())
 	if err != nil {
 		t.Errorf("failed to run 'kflex ctx delete %s': %v", ctxName, err)
 	}

--- a/cmd/kflex/ctx/rename.go
+++ b/cmd/kflex/ctx/rename.go
@@ -24,7 +24,6 @@ import (
 	"github.com/kubestellar/kubeflex/pkg/certs"
 	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -63,47 +62,11 @@ func ExecuteCtxRename(cp common.CP, ctxName string, newCtxName string, toSwitch 
 	newClusterName := certs.GenerateClusterName(newCtxName)
 	newAuthInfoAdminName := certs.GenerateAuthInfoAdminName(newCtxName)
 	newCtxName = certs.GenerateContextName(newCtxName)
-
-	// Preserve the original context's extensions when creating the new context
-	originalContext := kconf.Contexts[ctxName]
-	newContext := &api.Context{
-		Cluster:  newClusterName,
-		AuthInfo: newAuthInfoAdminName,
+	kconf.Contexts[newCtxName] = &api.Context{
+		Cluster:    newClusterName,
+		AuthInfo:   newAuthInfoAdminName,
+		Extensions: kconf.Contexts[ctxName].Extensions, // just copy as-is
 	}
-
-	// Copy extensions from the original context to preserve KubeFlex metadata
-	if originalContext.Extensions != nil {
-		newContext.Extensions = make(map[string]runtime.Object)
-		for key, value := range originalContext.Extensions {
-			// For KubeFlex extensions, we need to update the extension data to reflect the new context name
-			if key == kubeconfig.ExtensionKubeflexKey {
-				// Parse the existing extension
-				runtimeExtension := &kubeconfig.RuntimeKubeflexExtension{}
-				if err := kubeconfig.ConvertRuntimeObjectToRuntimeExtension(value, runtimeExtension); err == nil {
-					// Update the extension data to reflect the new context name
-					if runtimeExtension.Data != nil {
-						// Update the control plane name if it matches the old context name
-						if cpName, exists := runtimeExtension.Data[kubeconfig.ExtensionControlPlaneName]; exists && cpName == ctxName {
-							runtimeExtension.Data[kubeconfig.ExtensionControlPlaneName] = newCtxName
-						}
-						// Update the initial context name if it matches the old context name
-						if initialCtxName, exists := runtimeExtension.Data[kubeconfig.ExtensionInitialContextName]; exists && initialCtxName == ctxName {
-							runtimeExtension.Data[kubeconfig.ExtensionInitialContextName] = newCtxName
-						}
-					}
-					newContext.Extensions[key] = runtimeExtension
-				} else {
-					// If we can't parse the extension, just copy it as-is
-					newContext.Extensions[key] = value
-				}
-			} else {
-				// For non-KubeFlex extensions, copy as-is
-				newContext.Extensions[key] = value
-			}
-		}
-	}
-
-	kconf.Contexts[newCtxName] = newContext
 	if cluster, ok := kconf.Clusters[certs.GenerateClusterName(ctxName)]; ok {
 		fmt.Fprintf(os.Stdout, "renaming cluster to %s\n", newClusterName)
 		newCluster := *cluster

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -383,3 +383,14 @@ func WaitForNamespaceReady(ctx context.Context, clientset kubernetes.Interface, 
 	}
 	return nil
 }
+
+// IsContextManagedByKubeflex checks if a context is managed by KubeFlex
+// by checking if it has the kubeflex extension
+func IsContextManagedByKubeflex(kconf *clientcmdapi.Config, ctxName string) bool {
+	ctx, exists := kconf.Contexts[ctxName]
+	if !exists {
+		return false
+	}
+	_, hasKubeflexExtension := ctx.Extensions[ExtensionKubeflexKey]
+	return hasKubeflexExtension
+}

--- a/test/e2e/manage-ctx.sh
+++ b/test/e2e/manage-ctx.sh
@@ -58,7 +58,7 @@ echo "TEST: kflex ctx rename PASSED"
 : -------------------------------------------------------------------------
 : Delete context $NEW_CTX_NAME and verify it is removed from kubeconfig file
 :
-./bin/kflex ctx delete ${NEW_CTX_NAME}
+./bin/kflex ctx delete ${NEW_CTX_NAME} --force
 
 :
 : -------------------------------------------------------------------------


### PR DESCRIPTION
Summary :-

This PR implements a safety guard for the kflex ctx delete command to prevent accidental deletion of Kubernetes contexts not managed by KubeFlex.

Changes
	•	Added IsContextManagedByKubeflex function to detect if a context is managed by KubeFlex.
	•	Modified ExecuteCtxDelete to:
	•	Display a warning if the context is not managed by KubeFlex.
	•	Prompt the user for confirmation before deleting non-managed contexts.
	•	Support a --force flag to bypass confirmation for automation.
	•	Updated tests to cover both KubeFlex-managed and non-managed contexts.

closes #392 
