### PR TITLE
✨ feature : kflex config diagnose

### DIFF
--- a/cmd/kflex/config/config.go
+++ b/cmd/kflex/config/config.go
@@ -28,5 +28,6 @@ func Command() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 	}
 	command.AddCommand(CommandSetHostingClusterCtx())
+	command.AddCommand(CommandDiagnose())
 	return command
 }

--- a/cmd/kflex/config/diagnose.go
+++ b/cmd/kflex/config/diagnose.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+	"github.com/spf13/cobra"
+)
+
+// DiagnosisResult represents the result of the kubeflex extension diagnosis
+type DiagnosisResult struct {
+	Status  string                    `json:"status"`
+	Message string                    `json:"message"`
+	Data    *kubeconfig.KubeflexExtensions `json:"data,omitempty"`
+}
+
+func CommandDiagnose() *cobra.Command {
+	var jsonOutput bool
+	
+	command := &cobra.Command{
+		Use:   "diagnose",
+		Short: "Diagnose kubeflex extension status",
+		Long:  `Check the status of the global kubeflex extension in the kubeconfig file`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			flagset := cmd.Flags()
+			kubeconfigFile, err := flagset.GetString(common.KubeconfigFlag)
+			if err != nil {
+				return fmt.Errorf("error while parsing --kubeconfig: %v", err)
+			}
+			return ExecuteDiagnose(kubeconfigFile, jsonOutput)
+		},
+	}
+	
+	command.Flags().BoolVarP(&jsonOutput, "json", "j", false, "output in JSON format")
+	return command
+}
+
+// ExecuteDiagnose checks the status of the global kubeflex extension
+func ExecuteDiagnose(kubeconfigFile string, jsonOutput bool) error {
+	kconf, err := kubeconfig.LoadKubeconfig(kubeconfigFile)
+	if err != nil {
+		return fmt.Errorf("error while loading kubeconfig: %v", err)
+	}
+	
+	status, data := kubeconfig.CheckGlobalKubeflexExtension(*kconf)
+	
+	result := DiagnosisResult{
+		Status:  status,
+		Data:    data,
+	}
+	
+	// Set appropriate message based on status
+	switch status {
+	case "critical":
+		result.Message = "Global kubeflex extension is not present in kubeconfig"
+	case "warning":
+		result.Message = "Global kubeflex extension is present but empty"
+	case "ok":
+		result.Message = "Global kubeflex extension is present and properly configured"
+	}
+	
+	if jsonOutput {
+		jsonData, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("error while marshaling JSON: %v", err)
+		}
+		fmt.Println(string(jsonData))
+	} else {
+		// CLI-readable output
+		fmt.Printf("Status: %s\n", result.Status)
+		fmt.Printf("Message: %s\n", result.Message)
+		if data != nil && data.HostingClusterContextName != "" {
+			fmt.Printf("Hosting Cluster Context: %s\n", data.HostingClusterContextName)
+		}
+	}
+	
+	return nil
+}

--- a/cmd/kflex/config/diagnose_test.go
+++ b/cmd/kflex/config/diagnose_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"path"
+	"testing"
+
+	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// setupKubeconfigCritical creates a kubeconfig without kubeflex extension
+func setupKubeconfigCritical(t *testing.T, kubeconfigPath string) {
+	kconf := api.NewConfig()
+	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
+		t.Fatalf("error writing kubeconfig: %v", err)
+	}
+}
+
+// setupKubeconfigWarning creates a kubeconfig with empty kubeflex extension
+func setupKubeconfigWarning(t *testing.T, kubeconfigPath string) {
+	kconf := api.NewConfig()
+	runtimeExtension := kubeconfig.NewRuntimeKubeflexExtension()
+	kconf.Extensions[kubeconfig.ExtensionKubeflexKey] = runtimeExtension
+	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
+		t.Fatalf("error writing kubeconfig: %v", err)
+	}
+}
+
+// setupKubeconfigOk creates a kubeconfig with valid kubeflex extension
+func setupKubeconfigOk(t *testing.T, kubeconfigPath string) {
+	kconf := api.NewConfig()
+	kflexConfig, err := kubeconfig.NewKubeflexConfig(*kconf)
+	if err != nil {
+		t.Fatalf("error creating kubeflex config: %v", err)
+	}
+	kflexConfig.Extensions.HostingClusterContextName = "test-hosting-cluster"
+	
+	runtimeExtension := kubeconfig.NewRuntimeKubeflexExtension()
+	if err = kflexConfig.ConvertExtensionsToRuntimeExtension(runtimeExtension); err != nil {
+		t.Fatalf("error converting extensions: %v", err)
+	}
+	
+	runtimeExtensions, err := kflexConfig.ParseToKubeconfigExtensions()
+	if err != nil {
+		t.Fatalf("error parsing to kubeconfig extensions: %v", err)
+	}
+	kconf.Extensions[kubeconfig.ExtensionKubeflexKey] = runtimeExtensions[kubeconfig.ExtensionKubeflexKey]
+	
+	if err := kubeconfig.WriteKubeconfig(kubeconfigPath, kconf); err != nil {
+		t.Fatalf("error writing kubeconfig: %v", err)
+	}
+}
+
+// Test diagnose with critical status (no extension)
+func TestExecuteDiagnose_Critical(t *testing.T) {
+	kubeconfigPath := path.Join(t.TempDir(), "testconfig")
+	setupKubeconfigCritical(t, kubeconfigPath)
+	
+	err := ExecuteDiagnose(kubeconfigPath, false)
+	if err != nil {
+		t.Errorf("ExecuteDiagnose failed: %v", err)
+	}
+}
+
+// Test diagnose with warning status (empty extension)
+func TestExecuteDiagnose_Warning(t *testing.T) {
+	kubeconfigPath := path.Join(t.TempDir(), "testconfig")
+	setupKubeconfigWarning(t, kubeconfigPath)
+	
+	err := ExecuteDiagnose(kubeconfigPath, false)
+	if err != nil {
+		t.Errorf("ExecuteDiagnose failed: %v", err)
+	}
+}
+
+// Test diagnose with ok status (valid extension)
+func TestExecuteDiagnose_Ok(t *testing.T) {
+	kubeconfigPath := path.Join(t.TempDir(), "testconfig")
+	setupKubeconfigOk(t, kubeconfigPath)
+	
+	err := ExecuteDiagnose(kubeconfigPath, false)
+	if err != nil {
+		t.Errorf("ExecuteDiagnose failed: %v", err)
+	}
+}
+
+// Test diagnose with JSON output
+func TestExecuteDiagnose_JSON(t *testing.T) {
+	kubeconfigPath := path.Join(t.TempDir(), "testconfig")
+	setupKubeconfigOk(t, kubeconfigPath)
+	
+	err := ExecuteDiagnose(kubeconfigPath, true)
+	if err != nil {
+		t.Errorf("ExecuteDiagnose failed: %v", err)
+	}
+}
+
+// Test diagnose with invalid kubeconfig file
+func TestExecuteDiagnose_InvalidFile(t *testing.T) {
+	err := ExecuteDiagnose("/non/existent/file", false)
+	if err == nil {
+		t.Errorf("expected error for non-existent kubeconfig file")
+	}
+}
+
+func TestDiagnosisResultJSON(t *testing.T) {
+	result := DiagnosisResult{
+		Status:  "ok",
+		Message: "Global kubeflex extension is present and properly configured",
+		Data: &kubeconfig.KubeflexExtensions{
+			HostingClusterContextName: "test-cluster",
+		},
+	}
+
+	jsonData, err := json.Marshal(result)
+	if err != nil {
+		t.Errorf("failed to marshal DiagnosisResult to JSON: %v", err)
+	}
+
+	var unmarshaled DiagnosisResult
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	if err != nil {
+		t.Errorf("failed to unmarshal DiagnosisResult from JSON: %v", err)
+	}
+
+	if unmarshaled.Status != result.Status {
+		t.Errorf("expected status %s, got %s", result.Status, unmarshaled.Status)
+	}
+	if unmarshaled.Message != result.Message {
+		t.Errorf("expected message %s, got %s", result.Message, unmarshaled.Message)
+	}
+	if unmarshaled.Data == nil || unmarshaled.Data.HostingClusterContextName != result.Data.HostingClusterContextName {
+		t.Errorf("expected hosting cluster context %s, got %s", result.Data.HostingClusterContextName, unmarshaled.Data.HostingClusterContextName)
+	}
+}

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -92,11 +92,7 @@ func TestCheckGlobalKubeflexExtensionWarning(t *testing.T) {
 	kconf := api.NewConfig()
 	
 	runtimeExtension := NewRuntimeKubeflexExtension()
-	runtimeExtensions, err := runtimeExtension.ConvertExtensionsToRuntimeExtension(runtimeExtension)
-	if err != nil {
-		t.Fatalf("failed to convert extensions: %v", err)
-	}
-	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtensions[ExtensionKubeflexKey]
+	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtension
 	
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	


### PR DESCRIPTION
## Summary
Implement `kube config diagnose` to detect if the global Kubeflex extension is set.
Relates to #388 