### PR TITLE
🌱 test : CheckGlobalKubeflexExtension

### DIFF
--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -35,9 +35,9 @@ const (
 	ExtensionKubeflexKey               = "kubeflex"
 	TypeExtensionDefault               = "extensions"
 	TypeExtensionLegacy                = "preferences[].extensions"
-	ExtensionStatusCritical            = "critical"
-	ExtensionStatusWarning             = "warning"
-	ExtensionStatusOK                  = "ok"
+	DiagnosisStatusCritical            = "critical"
+	DiagnosisStatusWarning             = "warning"
+	DiagnosisStatusOK                  = "ok"
 )
 
 // Internal structure of Kubeflex global extension in a Kubeconfig file
@@ -185,24 +185,24 @@ func ConvertRuntimeObjectToRuntimeExtension(data runtime.Object, receiver *Runti
 func CheckGlobalKubeflexExtension(kconf clientcmdapi.Config) (string, *KubeflexExtensions) {
 	runtimeObj, exists := kconf.Extensions[ExtensionKubeflexKey]
 	if !exists {
-		return ExtensionStatusCritical, nil
+		return DiagnosisStatusCritical, nil
 	}
 
 	runtimeExtension := &RuntimeKubeflexExtension{}
 	if err := ConvertRuntimeObjectToRuntimeExtension(runtimeObj, runtimeExtension); err != nil {
-		return ExtensionStatusCritical, nil
+		return DiagnosisStatusCritical, nil
 	}
 
 	// Check if the extension has any data
 	if len(runtimeExtension.Data) == 0 {
-		return ExtensionStatusWarning, nil
+		return DiagnosisStatusWarning, nil
 	}
 
 	// Parse the data into KubeflexExtensions
 	kflexConfig := newKflexConfig[KubeflexExtensions](kconf)
 	if err := kflexConfig.ConvertRuntimeExtensionToExtensions(runtimeExtension); err != nil {
-		return ExtensionStatusCritical, nil
+		return DiagnosisStatusCritical, nil
 	}
 
-	return ExtensionStatusOK, kflexConfig.Extensions
+	return DiagnosisStatusOK, kflexConfig.Extensions
 }

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -79,8 +79,8 @@ func TestCheckGlobalKubeflexExtensionNotSet(t *testing.T) {
 	kconf := api.NewConfig()	
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != "critical" {
-		t.Errorf("Expected status 'critical', got '%s'", status)
+	if status != ExtensionStatusCritical {
+		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusCritical, status)
 	}
 	if data != nil {
 		t.Errorf("Expected data to be nil, got %v", data)
@@ -98,8 +98,8 @@ func TestCheckGlobalKubeflexExtensionEmpty(t *testing.T) {
 	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtension
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != "warning" {
-		t.Errorf("Expected status 'warning', got '%s'", status)
+	if status != ExtensionStatusWarning {
+		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusWarning, status)
 	}
 	if data != nil {
 		t.Errorf("Expected data to be nil, got %v", data)
@@ -126,8 +126,8 @@ func TestCheckGlobalKubeflexExtensionWithData(t *testing.T) {
 	
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != "ok" {
-		t.Errorf("Expected status 'ok', got '%s'", status)
+	if status != ExtensionStatusOK {
+		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusOK, status)
 	}
 	if data == nil {
 		t.Errorf("Expected data to not be nil")

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -73,3 +73,65 @@ func TestKubeflexConfigWrittenAsKubeConfig(t *testing.T) {
 		t.Errorf("fail to setup kubeflex config as HostingClusterContextName is not '%s': value is %s", hostingClusterContextNameExistent, v)
 	}
 }
+
+// Test CheckGlobalKubeflexExtension when extension is not set
+func TestCheckGlobalKubeflexExtensionNotSet(t *testing.T) {
+	kconf := api.NewConfig()	
+	status, data := CheckGlobalKubeflexExtension(*kconf)
+	
+	if status != "critical" {
+		t.Errorf("Expected status 'critical', got '%s'", status)
+	}
+	if data != nil {
+		t.Errorf("Expected data to be nil, got %v", data)
+	}
+}
+
+// Test CheckGlobalKubeflexExtension when extension is set but empty
+func TestCheckGlobalKubeflexExtensionEmpty(t *testing.T) {
+	kconf := api.NewConfig()
+	
+	// Create an empty runtime extension
+	runtimeExtension := NewRuntimeKubeflexExtension()
+	
+	// Don't add any data to the extension
+	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtension
+	status, data := CheckGlobalKubeflexExtension(*kconf)
+	
+	if status != "warning" {
+		t.Errorf("Expected status 'warning', got '%s'", status)
+	}
+	if data != nil {
+		t.Errorf("Expected data to be nil, got %v", data)
+	}
+}
+
+// Test CheckGlobalKubeflexExtension when extension is set with valid data
+func TestCheckGlobalKubeflexExtensionWithData(t *testing.T) {
+	kconf := api.NewConfig()
+	
+	// Create a kubeflex config with data
+	kflexConfig, err := NewKubeflexConfig(*kconf)
+	if err != nil {
+		t.Fatalf("Failed to create kubeflex config: %v", err)
+	}
+	kflexConfig.Extensions.HostingClusterContextName = "test-hosting-cluster"
+	
+	// Convert to runtime extension and add to kubeconfig
+	runtimeExtension := NewRuntimeKubeflexExtension()
+	if err = kflexConfig.ConvertExtensionsToRuntimeExtension(runtimeExtension); err != nil {
+		t.Fatalf("Failed to convert extensions to runtime extension: %v", err)
+	}
+	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtension
+	
+	status, data := CheckGlobalKubeflexExtension(*kconf)
+	
+	if status != "ok" {
+		t.Errorf("Expected status 'ok', got '%s'", status)
+	}
+	if data == nil {
+		t.Errorf("Expected data to not be nil")
+	} else if data.HostingClusterContextName != "test-hosting-cluster" {
+		t.Errorf("Expected HostingClusterContextName to be 'test-hosting-cluster', got '%s'", data.HostingClusterContextName)
+	}
+}

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -79,8 +79,8 @@ func TestCheckGlobalKubeflexExtensionNotSet(t *testing.T) {
 	kconf := api.NewConfig()	
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != ExtensionStatusCritical {
-		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusCritical, status)
+	if status != DiagnosisStatusCritical {
+		t.Errorf("Expected status '%s', got '%s'", DiagnosisStatusCritical, status)
 	}
 	if data != nil {
 		t.Errorf("Expected data to be nil, got %v", data)
@@ -98,8 +98,8 @@ func TestCheckGlobalKubeflexExtensionEmpty(t *testing.T) {
 	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtension
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != ExtensionStatusWarning {
-		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusWarning, status)
+	if status != DiagnosisStatusWarning {
+		t.Errorf("Expected status '%s', got '%s'", DiagnosisStatusWarning, status)
 	}
 	if data != nil {
 		t.Errorf("Expected data to be nil, got %v", data)
@@ -126,8 +126,8 @@ func TestCheckGlobalKubeflexExtensionWithData(t *testing.T) {
 	
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != ExtensionStatusOK {
-		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusOK, status)
+	if status != DiagnosisStatusOK {
+		t.Errorf("Expected status '%s', got '%s'", DiagnosisStatusOK, status)
 	}
 	if data == nil {
 		t.Errorf("Expected data to not be nil")


### PR DESCRIPTION
## Summary
Create 3 tests for CheckGlobalKubeflexExtension for the following cases : 

1. Extension is not set
2. Extension is set but empty
3. Extension is set

Note : This PR should be reviewed after #456 

## Related issue(s)
redpinecube/kubeflex#8
Relates to #388 