### PR TITLE
 ✨ feature : implement initial kflex config diagnose

### DIFF
--- a/cmd/kflex/config/config.go
+++ b/cmd/kflex/config/config.go
@@ -28,5 +28,6 @@ func Command() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 	}
 	command.AddCommand(CommandSetHostingClusterCtx())
+	command.AddCommand(CommandDiagnose())
 	return command
 }

--- a/cmd/kflex/config/diagnose.go
+++ b/cmd/kflex/config/diagnose.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubestellar/kubeflex/cmd/kflex/common"
+	"github.com/kubestellar/kubeflex/pkg/kubeconfig"
+	"github.com/spf13/cobra"
+)
+
+// DiagnosisResult represents the result of the kubeflex extension diagnosis
+type DiagnosisResult struct {
+	Status  string                    `json:"status"`
+	Message string                    `json:"message"`
+	Data    *kubeconfig.KubeflexExtensions `json:"data,omitempty"`
+}
+
+func CommandDiagnose() *cobra.Command {
+	var jsonOutput bool
+
+	command := &cobra.Command{
+		Use:   "diagnose",
+		Short: "Diagnose kubeflex extension status",
+		Long:  `Check the status of the global kubeflex extension in the kubeconfig file`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			flagset := cmd.Flags()
+			kubeconfigFile, err := flagset.GetString(common.KubeconfigFlag)
+			if err != nil {
+				return fmt.Errorf("error while parsing --kubeconfig: %v", err)
+			}
+			return ExecuteDiagnose(kubeconfigFile, jsonOutput)
+		},
+	}
+
+	command.Flags().BoolVarP(&jsonOutput, "json", "j", false, "output in JSON format")
+	return command
+}
+
+// ExecuteDiagnose checks the status of the global kubeflex extension
+func ExecuteDiagnose(kubeconfigFile string, jsonOutput bool) error {
+	kconf, err := kubeconfig.LoadKubeconfig(kubeconfigFile)
+	if err != nil {
+		return fmt.Errorf("error while loading kubeconfig: %v", err)
+	}
+
+	status, data := kubeconfig.CheckGlobalKubeflexExtension(*kconf)
+
+	result := DiagnosisResult{
+		Status:  status,
+		Data:    data,
+	}
+
+	// Set appropriate message based on status
+	switch status {
+	case "critical":
+		result.Message = "Global kubeflex extension is not present in kubeconfig"
+	case "warning":
+		result.Message = "Global kubeflex extension is present but empty"
+	case "ok":
+		result.Message = "Global kubeflex extension is present and properly configured"
+	}
+
+	if jsonOutput {
+		jsonData, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("error while marshaling JSON: %v", err)
+		}
+		fmt.Println(string(jsonData))
+	} else {
+		// CLI-readable output
+		fmt.Printf("Status: %s\n", result.Status)
+		fmt.Printf("Message: %s\n", result.Message)
+		if data != nil && data.HostingClusterContextName != "" {
+			fmt.Printf("Hosting Cluster Context: %s\n", data.HostingClusterContextName)
+		}
+	}
+
+	return nil
+}

--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -35,9 +35,9 @@ const (
 	ExtensionKubeflexKey               = "kubeflex"
 	TypeExtensionDefault               = "extensions"
 	TypeExtensionLegacy                = "preferences[].extensions"
-	ExtensionStatusCritical            = "critical"
-	ExtensionStatusWarning             = "warning"
-	ExtensionStatusOK                  = "ok"
+	DiagnosisStatusCritical            = "critical"
+	DiagnosisStatusWarning             = "warning"
+	DiagnosisStatusOK                  = "ok"
 )
 
 // Internal structure of Kubeflex global extension in a Kubeconfig file
@@ -185,24 +185,24 @@ func ConvertRuntimeObjectToRuntimeExtension(data runtime.Object, receiver *Runti
 func CheckGlobalKubeflexExtension(kconf clientcmdapi.Config) (string, *KubeflexExtensions) {
 	runtimeObj, exists := kconf.Extensions[ExtensionKubeflexKey]
 	if !exists {
-		return ExtensionStatusCritical, nil
+		return DiagnosisStatusCritical, nil
 	}
 
 	runtimeExtension := &RuntimeKubeflexExtension{}
 	if err := ConvertRuntimeObjectToRuntimeExtension(runtimeObj, runtimeExtension); err != nil {
-		return ExtensionStatusCritical, nil
+		return DiagnosisStatusCritical, nil
 	}
 
 	// Check if the extension has any data
 	if len(runtimeExtension.Data) == 0 {
-		return ExtensionStatusWarning, nil
+		return DiagnosisStatusWarning, nil
 	}
 
 	// Parse the data into KubeflexExtensions
 	kflexConfig := newKflexConfig[KubeflexExtensions](kconf)
 	if err := kflexConfig.ConvertRuntimeExtensionToExtensions(runtimeExtension); err != nil {
-		return ExtensionStatusCritical, nil
+		return DiagnosisStatusCritical, nil
 	}
 
-	return ExtensionStatusOK, kflexConfig.Extensions
+	return DiagnosisStatusOK, kflexConfig.Extensions
 }

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -79,8 +79,8 @@ func TestCheckGlobalKubeflexExtensionNotSet(t *testing.T) {
 	kconf := api.NewConfig()	
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != "critical" {
-		t.Errorf("Expected status 'critical', got '%s'", status)
+	if status != ExtensionStatusCritical {
+		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusCritical, status)
 	}
 	if data != nil {
 		t.Errorf("Expected data to be nil, got %v", data)
@@ -98,8 +98,8 @@ func TestCheckGlobalKubeflexExtensionEmpty(t *testing.T) {
 	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtension
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != "warning" {
-		t.Errorf("Expected status 'warning', got '%s'", status)
+	if status != ExtensionStatusWarning {
+		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusWarning, status)
 	}
 	if data != nil {
 		t.Errorf("Expected data to be nil, got %v", data)
@@ -126,8 +126,8 @@ func TestCheckGlobalKubeflexExtensionWithData(t *testing.T) {
 	
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != "ok" {
-		t.Errorf("Expected status 'ok', got '%s'", status)
+	if status != ExtensionStatusOK {
+		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusOK, status)
 	}
 	if data == nil {
 		t.Errorf("Expected data to not be nil")

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -73,3 +73,65 @@ func TestKubeflexConfigWrittenAsKubeConfig(t *testing.T) {
 		t.Errorf("fail to setup kubeflex config as HostingClusterContextName is not '%s': value is %s", hostingClusterContextNameExistent, v)
 	}
 }
+
+// Test CheckGlobalKubeflexExtension when extension is not set
+func TestCheckGlobalKubeflexExtensionNotSet(t *testing.T) {
+	kconf := api.NewConfig()	
+	status, data := CheckGlobalKubeflexExtension(*kconf)
+	
+	if status != "critical" {
+		t.Errorf("Expected status 'critical', got '%s'", status)
+	}
+	if data != nil {
+		t.Errorf("Expected data to be nil, got %v", data)
+	}
+}
+
+// Test CheckGlobalKubeflexExtension when extension is set but empty
+func TestCheckGlobalKubeflexExtensionEmpty(t *testing.T) {
+	kconf := api.NewConfig()
+	
+	// Create an empty runtime extension
+	runtimeExtension := NewRuntimeKubeflexExtension()
+	
+	// Don't add any data to the extension
+	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtension
+	status, data := CheckGlobalKubeflexExtension(*kconf)
+	
+	if status != "warning" {
+		t.Errorf("Expected status 'warning', got '%s'", status)
+	}
+	if data != nil {
+		t.Errorf("Expected data to be nil, got %v", data)
+	}
+}
+
+// Test CheckGlobalKubeflexExtension when extension is set with valid data
+func TestCheckGlobalKubeflexExtensionWithData(t *testing.T) {
+	kconf := api.NewConfig()
+	
+	// Create a kubeflex config with data
+	kflexConfig, err := NewKubeflexConfig(*kconf)
+	if err != nil {
+		t.Fatalf("Failed to create kubeflex config: %v", err)
+	}
+	kflexConfig.Extensions.HostingClusterContextName = "test-hosting-cluster"
+	
+	// Convert to runtime extension and add to kubeconfig
+	runtimeExtension := NewRuntimeKubeflexExtension()
+	if err = kflexConfig.ConvertExtensionsToRuntimeExtension(runtimeExtension); err != nil {
+		t.Fatalf("Failed to convert extensions to runtime extension: %v", err)
+	}
+	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtension
+	
+	status, data := CheckGlobalKubeflexExtension(*kconf)
+	
+	if status != "ok" {
+		t.Errorf("Expected status 'ok', got '%s'", status)
+	}
+	if data == nil {
+		t.Errorf("Expected data to not be nil")
+	} else if data.HostingClusterContextName != "test-hosting-cluster" {
+		t.Errorf("Expected HostingClusterContextName to be 'test-hosting-cluster', got '%s'", data.HostingClusterContextName)
+	}
+}

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -79,8 +79,8 @@ func TestCheckGlobalKubeflexExtensionNotSet(t *testing.T) {
 	kconf := api.NewConfig()	
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != ExtensionStatusCritical {
-		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusCritical, status)
+	if status != DiagnosisStatusCritical {
+		t.Errorf("Expected status '%s', got '%s'", DiagnosisStatusCritical, status)
 	}
 	if data != nil {
 		t.Errorf("Expected data to be nil, got %v", data)
@@ -98,8 +98,8 @@ func TestCheckGlobalKubeflexExtensionEmpty(t *testing.T) {
 	kconf.Extensions[ExtensionKubeflexKey] = runtimeExtension
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != ExtensionStatusWarning {
-		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusWarning, status)
+	if status != DiagnosisStatusWarning {
+		t.Errorf("Expected status '%s', got '%s'", DiagnosisStatusWarning, status)
 	}
 	if data != nil {
 		t.Errorf("Expected data to be nil, got %v", data)
@@ -126,8 +126,8 @@ func TestCheckGlobalKubeflexExtensionWithData(t *testing.T) {
 	
 	status, data := CheckGlobalKubeflexExtension(*kconf)
 	
-	if status != ExtensionStatusOK {
-		t.Errorf("Expected status '%s', got '%s'", ExtensionStatusOK, status)
+	if status != DiagnosisStatusOK {
+		t.Errorf("Expected status '%s', got '%s'", DiagnosisStatusOK, status)
 	}
 	if data == nil {
 		t.Errorf("Expected data to not be nil")


### PR DESCRIPTION
## Summary
Implement the initial version of `kflex config diagnose` to check if the global kubeflex extension is set. 

Note : This PR should be reviewed after #457 

## Related issue(s)
redpinecube/kubeflex#9
Relates to #388 
