### PR TITLE
🌱 test & update : CheckHostingClusterContextNameNone

### DIFF
--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -207,13 +207,7 @@ func CheckGlobalKubeflexExtension(kconf clientcmdapi.Config) (string, *KubeflexE
 	return DiagnosisStatusOK, kflexConfig.Extensions
 }
 
-// CheckHostingClusterContextName checks the status of the hosting cluster context
-func CheckHostingClusterContextName(kconf clientcmdapi.Config) (string, *KubeflexExtensions) {
-	globalStatus, kflexExtension := CheckGlobalKubeflexExtension(kconf)
-	if globalStatus == DiagnosisStatusCritical || kflexExtension == nil {
-		return DiagnosisStatusCritical, nil
-	}
-
+func CheckHostingClusterContextName(kconf clientcmdapi.Config) string {
 	hostingClusterCtxCount := 0
 	for _, ctx := range kconf.Contexts {
 		if ctx.Extensions != nil {
@@ -231,10 +225,10 @@ func CheckHostingClusterContextName(kconf clientcmdapi.Config) (string, *Kubefle
 
 	switch hostingClusterCtxCount {
 	case 0:
-		return DiagnosisStatusCritical, kflexExtension
+		return DiagnosisStatusCritical
 	case 1:
-		return DiagnosisStatusOK, kflexExtension
+		return DiagnosisStatusOK
 	default:
-		return DiagnosisStatusWarning, kflexExtension
+		return DiagnosisStatusWarning
 	}
 }


### PR DESCRIPTION
## Summary

Testing ensures `CheckHostingClusterContextName` returns a `critical` status when no context is marked as a hosting cluster. Originally, this function depended on `CheckGlobalKubeflexExtension`, but it's preferable to remove that dependency to diagnose all potential issues collectively, rather than one at a time.
 
## Related issue(s)
redpinecube/kubeflex#14
#388