### PR TITLE
🌱 test : CheckHostingClusterContextName with a single hosting cluster

### DIFF
--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -207,13 +207,7 @@ func CheckGlobalKubeflexExtension(kconf clientcmdapi.Config) (string, *KubeflexE
 	return DiagnosisStatusOK, kflexConfig.Extensions
 }
 
-// CheckHostingClusterContextName checks the status of the hosting cluster context
-func CheckHostingClusterContextName(kconf clientcmdapi.Config) (string, *KubeflexExtensions) {
-	globalStatus, kflexExtension := CheckGlobalKubeflexExtension(kconf)
-	if globalStatus == DiagnosisStatusCritical || kflexExtension == nil {
-		return DiagnosisStatusCritical, nil
-	}
-
+func CheckHostingClusterContextName(kconf clientcmdapi.Config) string {
 	hostingClusterCtxCount := 0
 	for _, ctx := range kconf.Contexts {
 		if ctx.Extensions != nil {
@@ -231,10 +225,10 @@ func CheckHostingClusterContextName(kconf clientcmdapi.Config) (string, *Kubefle
 
 	switch hostingClusterCtxCount {
 	case 0:
-		return DiagnosisStatusCritical, kflexExtension
+		return DiagnosisStatusCritical
 	case 1:
-		return DiagnosisStatusOK, kflexExtension
+		return DiagnosisStatusOK
 	default:
-		return DiagnosisStatusWarning, kflexExtension
+		return DiagnosisStatusWarning
 	}
 }

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -186,3 +186,24 @@ func TestCheckHostingClusterContextNameMultiple(t *testing.T) {
 		t.Errorf("Expected %s, got %s", DiagnosisStatusWarning, result)
 	}
 }
+
+func TestCheckHostingClusterContextNameSingle(t *testing.T) {
+	kconf := api.NewConfig()
+	kconf.Clusters["cluster1"] = &api.Cluster{Server: "https://example.com:6443"}
+	kconf.AuthInfos["user1"] = &api.AuthInfo{Token: "token"}
+
+	ext := NewRuntimeKubeflexExtension()
+	ext.Data[ExtensionContextsIsHostingCluster] = "true"
+
+	kconf.Contexts["ctx1"] = &api.Context{
+		Cluster:    "cluster1",
+		AuthInfo:   "user1",
+		Extensions: map[string]runtime.Object{ExtensionKubeflexKey: ext},
+	}
+	kconf.CurrentContext = "ctx1"
+
+	result := CheckHostingClusterContextName(*kconf)
+	if result != DiagnosisStatusOK {
+		t.Errorf("Expected %s, got %s", DiagnosisStatusOK, result)
+	}
+}


### PR DESCRIPTION
## Summary

Test that `CheckHostingClusterContextName` returns `DiagnosisStatusOK` when there is a single hosting cluster context name set in the config. 

Note : Please review this PR after #464  

## Related issue(s)
redpinecube/kubeflex#16
#388 