### PR TITLE
✨ feature : implement CheckContextScopeKubeflexExtensionSet

### DIFF
--- a/pkg/kubeconfig/extensions.go
+++ b/pkg/kubeconfig/extensions.go
@@ -38,6 +38,7 @@ const (
 	DiagnosisStatusCritical            = "critical"
 	DiagnosisStatusWarning             = "warning"
 	DiagnosisStatusOK                  = "ok"
+	DiagnosisStatusMissing             = "no kubeflex extension found"
 )
 
 // Internal structure of Kubeflex global extension in a Kubeconfig file
@@ -233,33 +234,45 @@ func CheckHostingClusterContextName(kconf clientcmdapi.Config) string {
 	}
 }
 
-func CheckContextScopeKubeflexExtensionSet(kconf clientcmdapi.Config) string {
-	for _, ctx := range kconf.Contexts {
-		ext, ok := ctx.Extensions[ExtensionKubeflexKey]
-		if !ok {
-			continue // No kubeflex extension, skip
-		}
+func VerifyControlPlaneOnHostingCluster(kconf clientcmdapi.Config, ctxName string) string {
+	// TODO: implement actual control plane verification logic
+	return DiagnosisStatusOK
+}
 
-		ctxExtension := &RuntimeKubeflexExtension{}
-		if err := ConvertRuntimeObjectToRuntimeExtension(ext, ctxExtension); err != nil {
-			return DiagnosisStatusCritical
-		}
-
-		if ctxExtension.Data == nil {
-			return DiagnosisStatusCritical
-		}
-
-		// Check required fields
-		_, hostingOk := ctxExtension.Data[ExtensionContextsIsHostingCluster]
-		_, cpOk := ctxExtension.Data[ExtensionControlPlaneName]
-		hasName := ctxExtension.Name == ExtensionKubeflexKey
-		hasTimestamp := !ctxExtension.CreationTimestamp.IsZero()
-
-		if !(hostingOk && cpOk && hasName && hasTimestamp) {
-			return DiagnosisStatusWarning // Any invalid kubeflex extension = warning
-		}
+func CheckContextScopeKubeflexExtensionSet(kconf clientcmdapi.Config, ctxName string) string {
+	ctx, ok := kconf.Contexts[ctxName]
+	if !ok {
+		return DiagnosisStatusMissing // Context not found
 	}
 
-	// All kubeflex extensions valid or no kubeflex extensions present
+	ext, ok := ctx.Extensions[ExtensionKubeflexKey]
+	if !ok {
+		return DiagnosisStatusMissing // No kubeflex extension found
+	}
+
+	ctxExtension := &RuntimeKubeflexExtension{}
+	if err := ConvertRuntimeObjectToRuntimeExtension(ext, ctxExtension); err != nil {
+		return DiagnosisStatusCritical
+	}
+
+	if ctxExtension.Data == nil {
+		return DiagnosisStatusCritical
+	}
+
+	// Check required fields
+	_, hostingOk := ctxExtension.Data[ExtensionContextsIsHostingCluster]
+	_, cpOk := ctxExtension.Data[ExtensionControlPlaneName]
+	hasName := ctxExtension.Name == ExtensionKubeflexKey
+	hasTimestamp := !ctxExtension.CreationTimestamp.IsZero()
+
+	if !(hostingOk && cpOk && hasName && hasTimestamp) {
+		return DiagnosisStatusWarning
+	}
+
+	status := VerifyControlPlaneOnHostingCluster(kconf, ctxName)
+	if status != DiagnosisStatusOK {
+		return status
+	}
+
 	return DiagnosisStatusOK
 }


### PR DESCRIPTION
## Summary
Implements `CheckContextScopeKubeflexExtensionSet` to check if the data and metadata for context-scope extensions are set correctly. If no extensions exist or if no kubeflex extensions exists, returns `DiagnosisStatusOK`

## Related issue(s)
redpinecube/kubeflex#14
#388