### PR TITLE
🌱 test : CheckContextScopeKubeflexExtensionSet with no kubeflex extensions

### DIFF
--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -207,3 +207,18 @@ func TestCheckHostingClusterContextNameSingle(t *testing.T) {
 		t.Errorf("Expected %s, got %s", DiagnosisStatusOK, result)
 	}
 }
+
+func TestCheckContextScopeKubeflexExtensionSetNoKubeflexExtensions(t *testing.T) {
+	kconf := api.NewConfig()
+	kconf.Clusters["cluster1"] = &api.Cluster{Server: "https://example.com:6443"}
+	kconf.AuthInfos["user1"] = &api.AuthInfo{Token: "token"}
+	kconf.Contexts["ctx1"] = &api.Context{
+		Cluster:  "cluster1",
+		AuthInfo: "user1",
+	}
+	kconf.CurrentContext = "ctx1"
+	result := CheckContextScopeKubeflexExtensionSet(*kconf)
+	if result != DiagnosisStatusOK {
+		t.Errorf("Expected %s, got %s", DiagnosisStatusOK, result)
+	}
+}


### PR DESCRIPTION
## Summary
Checks that `CheckContextScopeKubeflexExtensionSet` returns `DiagnosisStatusOK` if there are no kubeflex extensions . 

Note : Please review this PR after #476  
## Related issue(s)
redpinecube/kubeflex#15 
#388 