### PR TITLE
🌱  test : CheckContextScopeKubeflexExtensionSet with partial data

### DIFF
--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -243,3 +243,25 @@ func TestCheckContextScopeKubeflexExtensionSetNoData(t *testing.T) {
 		t.Errorf("Expected %s, got %s", DiagnosisStatusCritical, result)
 	}
 }
+
+func TestCheckContextScopeKubeflexExtensionSetPartialData(t *testing.T) {
+	kconf := api.NewConfig()
+	kconf.Clusters["cluster1"] = &api.Cluster{Server: "https://example.com:6443"}
+	kconf.AuthInfos["user1"] = &api.AuthInfo{Token: "token"}
+
+	ext := NewRuntimeKubeflexExtension()
+	ext.Data[ExtensionContextsIsHostingCluster] = "true"
+	// Missing control-plane name
+
+	kconf.Contexts["ctx1"] = &api.Context{
+		Cluster:    "cluster1",
+		AuthInfo:   "user1",
+		Extensions: map[string]runtime.Object{ExtensionKubeflexKey: ext},
+	}
+	kconf.CurrentContext = "ctx1"
+
+	result := CheckContextScopeKubeflexExtensionSet(*kconf)
+	if result != DiagnosisStatusWarning {
+		t.Errorf("Expected %s, got %s", DiagnosisStatusWarning, result)
+	}
+}

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -207,3 +207,18 @@ func TestCheckHostingClusterContextNameSingle(t *testing.T) {
 		t.Errorf("Expected %s, got %s", DiagnosisStatusOK, result)
 	}
 }
+
+func TestCheckContextScopeKubeflexExtensionSetNoKubeflexExtensions(t *testing.T) {
+	kconf := api.NewConfig()
+	kconf.Clusters["cluster1"] = &api.Cluster{Server: "https://example.com:6443"}
+	kconf.AuthInfos["user1"] = &api.AuthInfo{Token: "token"}
+	kconf.Contexts["ctx1"] = &api.Context{
+		Cluster:  "cluster1",
+		AuthInfo: "user1",
+	}
+	kconf.CurrentContext = "ctx1"
+	result := CheckContextScopeKubeflexExtensionSet(*kconf)
+	if result != DiagnosisStatusOK {
+		t.Errorf("Expected %s, got %s", DiagnosisStatusOK, result)
+	}
+}

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -252,7 +252,6 @@ func TestCheckContextScopeKubeflexExtensionSetPartialData(t *testing.T) {
 
 	ext := NewRuntimeKubeflexExtension()
 	ext.Data[ExtensionContextsIsHostingCluster] = "true"
-	// Missing control-plane name
 
 	kconf.Contexts["ctx1"] = &api.Context{
 		Cluster:    "cluster1",
@@ -261,7 +260,7 @@ func TestCheckContextScopeKubeflexExtensionSetPartialData(t *testing.T) {
 	}
 	kconf.CurrentContext = "ctx1"
 
-	result := CheckContextScopeKubeflexExtensionSet(*kconf)
+	result := CheckContextScopeKubeflexExtensionSet(*kconf, "ctx1")
 	if result != DiagnosisStatusWarning {
 		t.Errorf("Expected %s, got %s", DiagnosisStatusWarning, result)
 	}

--- a/pkg/kubeconfig/extensions_test.go
+++ b/pkg/kubeconfig/extensions_test.go
@@ -222,3 +222,24 @@ func TestCheckContextScopeKubeflexExtensionSetNoKubeflexExtensions(t *testing.T)
 		t.Errorf("Expected %s, got %s", DiagnosisStatusOK, result)
 	}
 }
+
+func TestCheckContextScopeKubeflexExtensionSetNoData(t *testing.T) {
+	kconf := api.NewConfig()
+	kconf.Clusters["cluster1"] = &api.Cluster{Server: "https://example.com:6443"}
+	kconf.AuthInfos["user1"] = &api.AuthInfo{Token: "token"}
+
+	ext := NewRuntimeKubeflexExtension()
+	ext.Data = nil
+
+	kconf.Contexts["ctx1"] = &api.Context{
+		Cluster:    "cluster1",
+		AuthInfo:   "user1",
+		Extensions: map[string]runtime.Object{ExtensionKubeflexKey: ext},
+	}
+	kconf.CurrentContext = "ctx1"
+
+	result := CheckContextScopeKubeflexExtensionSet(*kconf)
+	if result != DiagnosisStatusCritical {
+		t.Errorf("Expected %s, got %s", DiagnosisStatusCritical, result)
+	}
+}


### PR DESCRIPTION
## Summary

Tests that `CheckContextScopeKubeflexExtensionSet` returns a warning status with partial data.

Note : Please review this PR after #478 

## Related issue(s)
redpinecube/kubeflex#20
#388