### PR TITLE
🐛 bug fix: Consolidate PostCreateHook error handling with retry logic in shared reconciler

### DIFF
--- a/pkg/reconcilers/shared/postcreate_hook.go
+++ b/pkg/reconcilers/shared/postcreate_hook.go
@@ -34,11 +34,14 @@ import (
 
 	"github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/pkg/util"
+	"errors"
 )
 
 const (
 	FieldManager = "kubeflex"
 )
+
+var ErrPostCreateHookNotFound = errors.New("post create hook not found")
 
 type Vars struct {
 	Namespace        string
@@ -106,9 +109,7 @@ func (r *BaseReconciler) ReconcileUpdatePostCreateHook(ctx context.Context, hcp 
 		// Get hook definition
 		pch := &v1alpha1.PostCreateHook{}
 		if err := r.Client.Get(ctx, client.ObjectKey{Name: hookName}, pch); err != nil {
-			errs = append(errs, fmt.Errorf("failed to get PostCreateHook %s: %w", hookName, err))
-			allHooksApplied = false
-			continue
+			return fmt.Errorf("%w: %v", ErrPostCreateHookNotFound, err)
 		}
 
 		// Build variables with precedence: defaults -> global -> user vars -> system

--- a/pkg/reconcilers/shared/reconciler.go
+++ b/pkg/reconcilers/shared/reconciler.go
@@ -19,6 +19,7 @@ package shared
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -66,6 +67,10 @@ func (r *BaseReconciler) UpdateStatusForSyncingError(hcp *tenancyv1alpha1.Contro
 	err := r.Status().Update(context.Background(), hcp)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(e, err.Error())
+	}
+	if errors.Is(e, ErrPostCreateHookNotFound) {
+		// Requeue after 10 seconds, don't mark as failed
+		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 	}
 	return ctrl.Result{}, err
 }

--- a/test/e2e/test-postcreatehook-retry.sh
+++ b/test/e2e/test-postcreatehook-retry.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "🧹 Cleaning up any existing resources..."
+kubectl delete controlplane cp-missing-hook --ignore-not-found=true
+kubectl delete postcreatehook missing-hook --ignore-not-found=true
+
+echo ""
+echo "🔧 Creating ControlPlane referencing a missing PostCreateHook..."
+kubectl apply -f - <<EOF
+apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
+kind: ControlPlane
+metadata:
+  name: cp-missing-hook
+spec:
+  backend: shared
+  postCreateHook: missing-hook
+  waitForPostCreateHooks: true
+  type: k8s
+EOF
+
+echo ""
+echo "⏳ Waiting 10s to check that ControlPlane is not marked as failed..."
+sleep 10
+
+echo ""
+echo "📋 ControlPlane status after 10s (should NOT be failed):"
+kubectl get controlplane cp-missing-hook -o jsonpath='{.status.conditions}' | jq '.'
+
+echo ""
+echo "🧪 Creating the missing PostCreateHook..."
+kubectl apply -f - <<EOF
+apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
+kind: PostCreateHook
+metadata:
+  name: missing-hook
+spec:
+  templates:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: job-missing-hook
+    spec:
+      template:
+        spec:
+          containers:
+          - name: demo
+            image: public.ecr.aws/docker/library/busybox:1.36
+            command: ["echo", "Hello from missing hook"]
+          restartPolicy: Never
+      backoffLimit: 1
+EOF
+
+echo ""
+echo "⏳ Waiting for ControlPlane to become Ready (90s timeout)..."
+kubectl wait --for=condition=Ready controlplane/cp-missing-hook --timeout=90s
+
+echo ""
+echo "📊 FINAL STATUS:"
+kubectl get controlplane cp-missing-hook -o jsonpath='{.status}' | jq '.'
+
+echo ""
+echo "🧹 Cleaning up test resources..."
+kubectl delete controlplane cp-missing-hook --ignore-not-found=true
+kubectl delete postcreatehook missing-hook --ignore-not-found=true


### PR DESCRIPTION
## Summary

This update improves how the system handles situations when a PostCreateHook is missing. Instead of failing, it now waits and retries automatically without causing errors or interruptions. The retry logic is centralized, making the code cleaner and easier to maintain. This ensures that control planes referring to hooks that aren’t created yet will keep working smoothly until those hooks become available.

## Tested  e2e
<img width="1551" height="869" alt="Screenshot 2025-07-27 023632" src="https://github.com/user-attachments/assets/c67cafe5-1346-4436-8bdf-59d0136419b8" />
also 
<img width="1031" height="679" alt="Screenshot 2025-07-27 023738" src="https://github.com/user-attachments/assets/f46553eb-a76e-4277-95e9-08aa76226987" />


## Related issue(s)

Fixes #319
