### PR TITLE
📖 Slack-Update: Update Slack reference to point to new CNCF Slack Channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to this project
 Greetings! We are grateful for your interest in joining the KubeStellar community and making a positive impact. Whether you're raising issues, enhancing documentation, fixing bugs, or developing new features, your contributions are essential to our success.
 
-To get started, kindly read through this document and familiarize yourself with our code of conduct. If you have any inquiries, please feel free to reach out to us on [Slack](https://kubernetes.slack.com/archives/C058SUSL5AA).
+To get started, kindly read through this document and familiarize yourself with our code of conduct. If you have any inquiries, please feel free to reach out to us on [Slack](https://cloud-native.slack.com/archives/C097094RZ3M).
 
 We can't wait to collaborate with you!
 
@@ -19,7 +19,7 @@ We can't wait to collaborate with you!
     - In go.mod it is indicated by the "go" directive.
     - In the .github/workflows yaml files it is indicated by "go-version"
     
-Check out our [QuickStart Guide](https://docs.kubestellar.io/stable/Getting-Started/quickstart/)
+Check out our [QuickStart Guide](https://docs.kubestellar.io/latest/direct/get-started/)
 
 ### Issues
 Prioritization for pull requests is given to those that address and resolve existing GitHub issues. Utilize the available issue labels to identify meaningful and relevant issues to work on.
@@ -56,7 +56,7 @@ Approvers will review your PR within a business day. A PR requires both an /lgtm
 
 Congratulations! Your pull request has been successfully merged! 👏
 
-If you have any questions about contributing, don't hesitate to reach out to us on the `kubestellar-dev` [Slack channel](https://kubernetes.slack.com/archives/C058SUSL5AA).
+If you have any questions about contributing, don't hesitate to reach out to us on the `kubestellar-dev` [Slack channel](https://cloud-native.slack.com/archives/C097094RZ3M).
 
 ## Testing Locally
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the Slack Channel Reference with the new Slack Channel `kubestellar-dev` under CNCF workspace. Also, updates the `QuickStart Guide` URL to reference the actual docs page.
## Related issue(s)

Fixes #
