### PR TITLE
🐛 ingress name and clusterrolebinding is attached to controlplane name

### DIFF
--- a/pkg/reconcilers/k3s/apiserver.go
+++ b/pkg/reconcilers/k3s/apiserver.go
@@ -69,8 +69,8 @@ func containerImage() string {
 }
 
 // serverTLSSAN returns the TLS SAN value expected by k3s server command
-func serverTLSSAN(cfg *shared.SharedConfig) string {
-	return "--tls-san=" + GetClusterStaticDNSRecord(cfg)
+func serverTLSSAN(cpName string, cfg *shared.SharedConfig) string {
+	return "--tls-san=" + GetClusterStaticDNSRecord(cpName, cfg)
 }
 
 func serverDataDir(path string) string {
@@ -120,7 +120,7 @@ func (r *Server) Prepare(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane)
 							// Command: is by default `/bin/k3s`
 							Args: []string{
 								"server",
-								serverTLSSAN(cfg),
+								serverTLSSAN(hcp.Name, cfg),
 								serverDataDir(StorageMountPath),
 							}, Env: []v1.EnvVar{
 								{Name: "K3S_CONTROLPLANE_SECRET_NAME", Value: KubeconfigSecretName},

--- a/pkg/reconcilers/k3s/ingress.go
+++ b/pkg/reconcilers/k3s/ingress.go
@@ -68,7 +68,7 @@ func (r *Ingress) Prepare(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane
 			APIVersion: "networking.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServerName,
+			Name:      hcp.Name,
 			Namespace: ComputeSystemNamespaceName(hcp.Name),
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
@@ -78,7 +78,7 @@ func (r *Ingress) Prepare(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane
 			IngressClassName: ptr.To(IngressClassNameNGINX),
 			Rules: []networkingv1.IngressRule{
 				{
-					Host: fmt.Sprintf("%s.%s", ServiceName, cfg.Domain),
+					Host: fmt.Sprintf("%s.%s", hcp.Name, cfg.Domain),
 
 					IngressRuleValue: networkingv1.IngressRuleValue{
 						HTTP: &networkingv1.HTTPIngressRuleValue{

--- a/pkg/reconcilers/k3s/job.go
+++ b/pkg/reconcilers/k3s/job.go
@@ -60,7 +60,7 @@ func (r *BootstrapSecretJob) Prepare(ctx context.Context, hcp *tenancyv1alpha1.C
 		return err
 	}
 	namespace := ComputeSystemNamespaceName(hcp.Name)
-	ingressDNS := GetClusterServerURI(cfg)
+	ingressDNS := GetClusterServerURI(hcp.Name, cfg)
 	serviceDNS := GetInClusterStaticDNSRecord(namespace)
 	r.Object = &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconcilers/k3s/rbac.go
+++ b/pkg/reconcilers/k3s/rbac.go
@@ -19,6 +19,7 @@ package k3s
 import (
 	"context"
 	_ "embed"
+	"fmt"
 
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/kubestellar/kubeflex/pkg/reconcilers/shared"
@@ -78,7 +79,7 @@ func (r *RBAC) Prepare(ctx context.Context, hcp *tenancyv1alpha1.ControlPlane) e
 	}
 	r.ClusterRoleBindingScriptsConfigMap = &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ScriptsConfigMapRoleBindingName,
+			Name: fmt.Sprintf("%s-%s", ScriptsConfigMapRoleBindingName, hcp.Name),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,

--- a/pkg/reconcilers/k3s/service.go
+++ b/pkg/reconcilers/k3s/service.go
@@ -90,13 +90,13 @@ func GetInClusterStaticDNSRecord(namespace string) string {
 }
 
 // GetClusterStaticDNSRecord fetch cluster dns in kubernetes form
-func GetClusterStaticDNSRecord(cfg *shared.SharedConfig) string {
-	return fmt.Sprintf("%s.%s", ServiceName, cfg.Domain)
+func GetClusterStaticDNSRecord(cpName string, cfg *shared.SharedConfig) string {
+	return fmt.Sprintf("%s.%s", cpName, cfg.Domain)
 }
 
 // GetClusterServerURI compute cluster server URI to reach the k3s server
-func GetClusterServerURI(cfg *shared.SharedConfig) string {
-	return fmt.Sprintf("https://%s:%d", GetClusterStaticDNSRecord(cfg), cfg.ExternalPort)
+func GetClusterServerURI(cpName string, cfg *shared.SharedConfig) string {
+	return fmt.Sprintf("https://%s:%d", GetClusterStaticDNSRecord(cpName, cfg), cfg.ExternalPort)
 }
 
 // Prepare service object and its manifest


### PR DESCRIPTION
## Summary

Before this PR, it was not possible to create 2 controlplanes of type k3s as they were sharing the common name for ingress and clusterrolebinding, putting the reconciling loop in error.

Now ingress and clusterrolebinding leverage controlplane name to their resource name.

## Related issue(s)

Fixes #510
