### PR TITLE
add cluster param to init command

### DIFF
--- a/cmd/kflex/init/cluster/kind.go
+++ b/cmd/kflex/init/cluster/kind.go
@@ -57,7 +57,7 @@ func installKind() error {
 	return nil
 }
 
-func checkKindInstanceExists() (bool, error) {
+func checkKindInstanceExists(clusterName string) (bool, error) {
 	cmd := exec.Command("kind", "get", "clusters")
 	out, err := cmd.Output()
 	if err != nil {
@@ -191,7 +191,7 @@ func installAndPatchNginxIngress() error {
 	return nil
 }
 
-func CreateKindCluster(chattyStatus bool) {
+func CreateKindCluster(chattyStatus bool, clusterName string) {
 	done := make(chan bool)
 	var wg sync.WaitGroup
 
@@ -212,7 +212,7 @@ func CreateKindCluster(chattyStatus bool) {
 	}
 
 	util.PrintStatus("Checking if a kubeflex kind instance already exists...", done, &wg, chattyStatus)
-	ok, err = checkKindInstanceExists()
+	ok, err = checkKindInstanceExists(clusterName)
 	if err != nil {
 		log.Fatalf("Error checking if kind instance already exists: %v\n", err)
 	}

--- a/cmd/kflex/init/init.go
+++ b/cmd/kflex/init/init.go
@@ -57,6 +57,7 @@ func Command() *cobra.Command {
 			domain, _ := flagset.GetString(DomainFlag)
 			externalPort, _ := flagset.GetInt(ExternalPortFlag)
 			hostContainer, _ := flagset.GetString(HostContainerNameFlag)
+			clusterName, _ := flagset.GetString("cluster-name")
 			done := make(chan bool)
 			var wg sync.WaitGroup
 			var isOCP bool
@@ -76,7 +77,7 @@ func Command() *cobra.Command {
 				if isOCP {
 					return fmt.Errorf("openShift cluster detected on existing context\nSwitch to a non-OpenShift context with `kubectl config use-context <context-name>` and retry")
 				}
-				cluster.CreateKindCluster(chattyStatus)
+				cluster.CreateKindCluster(chattyStatus, clusterName)
 			}
 
 			cp := common.NewCP(kubeconfig)
@@ -90,6 +91,7 @@ func Command() *cobra.Command {
 	flagset.StringP(DomainFlag, "d", "localtest.me", "domain for FQDN")
 	flagset.StringP(HostContainerNameFlag, "n", "kubeflex-control-plane", "Name of the hosting cluster container (kind or k3d only)")
 	flagset.IntP(ExternalPortFlag, "p", 9443, "external port used by ingress")
+	flagset.String("cluster-name", "kubeflex", "Name of the kind cluster to create")
 	return command
 }
 


### PR DESCRIPTION
## Add cluster name parameter to init command

This PR adds support for specifying a custom cluster name when creating a kind cluster with `kflex init.

### Changes
- Added `--cluster-name` flag to the `init` command (defaults to "kubeflex" for backward compatibility)
- Modified `CreateKindCluster()` and `checkKindInstanceExists()` functions to accept and use the cluster name parameter
- Updated cluster creation logic to use the provided name instead of hardcoded "kubeflex"

### Usage
```bash
# Create cluster with custom name
kflex init --create-kind --cluster-name my-test-cluster

# Creates kind cluster named "my-test-cluster" with context "kind-my-test-cluster"
```

### Motivation
Previously, users could only create one kubeflex installation at a time since the cluster name was hardcoded to "kubeflex". This prevented testing multiple configurations or features in parallel. Now users can create multiple isolated kubeflex environments with different cluster names.

Fixes the issue where parallel kubeflex installations would conflict due to identical cluster names.