### PR TITLE
🐛fix(kubeconfig): validate and ignore invalid saved hosting context, warn instead of failing

### DIFF
--- a/cmd/kflex/ctx/ctx.go
+++ b/cmd/kflex/ctx/ctx.go
@@ -103,10 +103,12 @@ func (cpCtx *CPCtx) ExecuteCtx(chattyStatus, failIfNone, overwriteExistingCtx, s
 		if kubeconfig.IsHostingClusterContextSet(kconf) {
 			util.PrintStatus("Switching to hosting cluster context...", done, &wg, chattyStatus)
 			if err = kubeconfig.SwitchToHostingClusterContext(kconf); err != nil {
-				return fmt.Errorf("error switching kubeconfig to hosting cluster context: %v", err)
-
+				// The stored hosting context is invalid (missing/removed cluster or server).
+				// Warn the user and proceed as if no hosting context was set.
+				fmt.Fprintf(os.Stderr, "warning: saved hosting cluster context is invalid, ignoring it: %v\n", err)
+			} else {
+				done <- true
 			}
-			done <- true
 		} else if failIfNone {
 			pclientset, err := kfclient.GetClientSet(cpCtx.Kubeconfig)
 			if err != nil {

--- a/pkg/kubeconfig/kubeconfig.go
+++ b/pkg/kubeconfig/kubeconfig.go
@@ -177,8 +177,21 @@ func GetHostingClusterContext(kconf *clientcmdapi.Config) (string, error) {
 		return "", fmt.Errorf("hosting cluster context data not set")
 	}
 	// make sure that context set in extension is a valid context
-	if _, ok := kconf.Contexts[kflexConfig.Extensions.HostingClusterContextName]; !ok {
+	ctxName := kflexConfig.Extensions.HostingClusterContextName
+	ctx, ok := kconf.Contexts[ctxName]
+	if !ok {
 		return "", fmt.Errorf("hosting cluster context data is set to a non-existing context")
+	}
+	// validate referenced cluster exists and has server info
+	if ctx.Cluster == "" {
+		return "", fmt.Errorf("hosting cluster context '%s' does not reference a cluster", ctxName)
+	}
+	cluster, ok := kconf.Clusters[ctx.Cluster]
+	if !ok {
+		return "", fmt.Errorf("cluster '%s' referenced by context '%s' does not exist", ctx.Cluster, ctxName)
+	}
+	if cluster.Server == "" {
+		return "", fmt.Errorf("cluster '%s' referenced by context '%s' has no server defined", ctx.Cluster, ctxName)
 	}
 	return kflexConfig.Extensions.HostingClusterContextName, nil
 }


### PR DESCRIPTION
## Summary
Validate the kubeconfig kubeflex extension before switching: map legacy key for compatibility, ignore non-existent or cluster-less contexts, print a clear warning and fall back safely. Includes unit tests for valid, missing and malformed saved contexts.

Fixes #202 
