### PR TITLE
✨ feat: add OCM deprecation warning to CLI

### DIFF
--- a/cmd/kflex/create/create.go
+++ b/cmd/kflex/create/create.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/fatih/color"
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,6 +77,11 @@ func Command() *cobra.Command {
 // TODO: each CLI command should be independant to each other
 // replace the use of cx.ExecuteCtx by another mean
 func ExecuteCreate(cp common.CP, controlPlaneType string, backendType string, hook string, hookVars []string, chattyStatus bool) error {
+	// Check for OCM deprecation warning
+	if controlPlaneType == string(tenancyv1alpha1.ControlPlaneTypeOCM) {
+		color.Yellow("WARNING: OCM-type control plane is deprecated and will be removed in a future version. Consider using k8s or vcluster type instead.")
+	}
+
 	done := make(chan bool)
 	var wg sync.WaitGroup
 	cx := cont.CPCtx{}                               // this is always undefined control plane, hence

--- a/test/e2e/test-ocm-deprecation-warning.sh
+++ b/test/e2e/test-ocm-deprecation-warning.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x # echo so that users can understand what is happening
+set -e # exit on error
+
+SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source "${SRC_DIR}/setup-shell.sh"
+
+OCM_CP_NAME="cp-ocm-test"
+K8S_CP_NAME="cp-k8s-test"
+
+cleanup() {
+    echo "Cleaning up test resources..."
+    kubectl delete controlplane "${OCM_CP_NAME}" --ignore-not-found=true
+    kubectl delete controlplane "${K8S_CP_NAME}" --ignore-not-found=true
+}
+
+trap cleanup EXIT
+
+:
+: -------------------------------------------------------------------------
+: Clean up any existing test resources
+:
+echo "Cleaning up any existing test resources..."
+cleanup
+
+:
+: -------------------------------------------------------------------------
+: Test case: OCM control plane creation should display deprecation warning
+:
+echo "Testing OCM deprecation warning display..."
+
+output=$(./bin/kflex create "${OCM_CP_NAME}" --type ocm --chatty-status=false 2>&1 || true)
+
+if echo "$output" | grep -q "WARNING: OCM-type control plane is deprecated"; then
+    echo "SUCCESS: OCM deprecation warning was displayed"
+else
+    echo "ERROR: OCM deprecation warning was not displayed"
+    echo "Command output:"
+    echo "$output"
+    exit 1
+fi
+
+:
+: -------------------------------------------------------------------------
+: Test case: Non-OCM control planes should NOT display deprecation warning
+:
+echo "Testing that non-OCM control planes don't show deprecation warning..."
+
+output=$(./bin/kflex create "${K8S_CP_NAME}" --type k8s --chatty-status=false 2>&1 || true)
+
+if echo "$output" | grep -q "WARNING: OCM-type control plane is deprecated"; then
+    echo "ERROR: OCM deprecation warning was incorrectly displayed for k8s control plane"
+    echo "Command output:"
+    echo "$output"
+    exit 1
+else
+    echo "SUCCESS: OCM deprecation warning was not displayed for k8s control plane"
+fi
+
+:
+: -------------------------------------------------------------------------
+: SUCCESS: OCM deprecation warning test completed
+:
+echo "Test completed successfully"


### PR DESCRIPTION
## Summary

Added a deprecation warning for OCM-type control plane creation in the kflex CLI.

## What I did

**In `create.go`:**
- Added a check at the start of `ExecuteCreate()` function
- Shows yellow warning when `--type ocm` is used: *"WARNING: OCM-type control plane is deprecated and will be removed in a future version. Consider using k8s or vcluster type instead."*
- Warning appears before control plane creation starts
- Only triggers for OCM type - k8s/vcluster work normally

**In `test-ocm-deprecation-warning.sh`:**
- Tests that OCM type shows the warning
- Tests that k8s type doesn't show the warning  


## See how it looks :
```txt
rayyan@rayyan-seliya:/mnt/c/Users/RAYYAN/Desktop/kubeflex$ 
./bin/kflex create test-ocm --type ocm --chatty-status=false
WARNING: current kflex version introduces BREAKING CHANGES related to kflex and your kubeconfig file which may interrupt kflex to function properly.
See https://github.com/kubestellar/kubeflex/blob/main/docs/users.md
WARNING: OCM-type control plane is deprecated and will be removed in a future version. Consider using k8s or vcluster type instead.
✔ Checking for saved hosting cluster context...
```

Also  feel free to  provide a feedback  for better warning description !

## Related issue(s)

Fixes #530