### PR TITLE
✨ docs: remove OCM from user-facing docs; point to vcluster for OCM-style workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ KubeFlex implements a sophisticated multi-tenant architecture that separates con
 ### Supported Control Plane Types
 
 - **k8s**: Lightweight Kubernetes API server (~350MB) with essential controllers, using shared Postgres via Kine
-- **vcluster**: Full virtual clusters based on the vCluster project, sharing host cluster worker nodes
+- **vcluster**: Full virtual clusters based on the vCluster project, sharing host cluster worker nodes. Note: OCM-style/multi-cluster federation workflows are supported via integrations running on vcluster when required.
 - **host**: The hosting cluster itself exposed as a control plane for management scenarios
-- **ocm**: Open Cluster Management control plane for multi-cluster federation scenarios
 - **external**: Import existing external clusters under KubeFlex management (roadmap)
 
 For detailed architecture information, see the [Architecture Guide](docs/architecture.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,11 +32,8 @@ plane can run pods using worker nodes of the hosting cluster.
 - *external*: an external cluster that is imported as a control plane (this
 is in the roadmap but not yet implemented)
 
-- *ocm*: a control plane that uses the 
-[multicluster-controlplane project](https://github.com/open-cluster-management-io/multicluster-controlplane) 
-for managing multiple clusters.
+- (Deprecated in docs) Traditional OCM-specific control plane references have been removed from the primary supported list. OCM-style multi-cluster/federation workflows are supported via integrations running on `vcluster` instances when needed. See the `vcluster` type below for details.
 
-When using KubeFlex, users interact with the API server 
 of the hosting cluster to create or delete control planes.
 KubeFlex defines a ControlPlane CRD that represents a Control Plane.
 

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -28,8 +28,7 @@ As organizations scale their Kubernetes adoption, they face a fundamental questi
 
 **What KubeFlex Integrates With:**
 - **KubeVirt**: For VM-based worker nodes providing complete tenant isolation
-- **vCluster**: As a control plane type for lightweight virtual clusters
-- **Open Cluster Management**: For multi-cluster scenarios and edge deployments
+- **vCluster**: As a control plane type for lightweight virtual clusters; vcluster instances can host integrations for multi-cluster/federation workflows
 - **Standard Kubernetes Storage**: CSI drivers, persistent volumes, and storage classes
 
 **Integration Boundaries:**
@@ -54,7 +53,7 @@ KubeFlex focuses on control plane management and provides integration points rat
 
 ### 4. Edge and Multi-Cluster Management
 - **Challenge**: Manage multiple edge locations with varying connectivity
-- **Solution**: Use `ocm` type control planes for edge cluster federation
+- **Solution**: Use `vcluster` instances (and integrations running on them) for edge cluster federation and OCM-style multi-cluster workflows
 - **Benefit**: Centralized management with distributed execution
 
 ## Advanced Configuration

--- a/docs/users.md
+++ b/docs/users.md
@@ -341,26 +341,28 @@ the URL for the server as `https://kubeflex-control-plane:<nodeport>`
 
 
 ## Control Plane Types
+At this time KubeFlex focuses documentation on the following supported control plane types:
 
-At this time KubFlex supports the following control plane types:
-
-- k8s: this is the stock Kube API server with a subset of controllers running in the controller manager.
-- ocm: this is the [Open Cluster Management Multicluster Control Plane](https://github.com/open-cluster-management-io/multicluster-controlplane), which provides a basic set of capabilities such as
-clusters registration and support for the [`ManifestWork` API](https://open-cluster-management.io/concepts/manifestwork/).
-- vcluster: this is based on the [vcluster project](https://www.vcluster.com) and provides the ability to create pods in the hosting namespace of the hosting cluster.
-- host: this control plane type exposes the underlying hosting cluster with the same control plane abstraction
-used by the other control plane types.
-- external: this control plane type represents an existing cluster that was not created by KubeFlex and is not the KubeFlex hosting cluster.
+- k8s: the stock Kubernetes API server with a subset of controllers active in the controller manager.
+- vcluster: virtual clusters based on the vCluster project that run on the hosting cluster; they can run pods and host integrations. Note: OCM-style multi-cluster/federation workflows (for example ManifestWork-like functionality) are supported by deploying integrations to `vcluster` instances when required.
+- host: exposes the underlying hosting cluster as a control plane using the same abstraction as other types.
+- external: represents an existing cluster that was not created by KubeFlex and is managed by adoption workflows.
+ - k8s: this is the stock Kube API server with a subset of controllers running in the controller manager.
+ - vcluster: this is based on the [vcluster project](https://www.vcluster.com) and provides the ability to create pods in the hosting namespace of the hosting cluster. Note: OCM-style multi-cluster federation and ManifestWork-like workflows are supported via integrations deployed to `vcluster` instances when needed.
+ - host: this control plane type exposes the underlying hosting cluster with the same control plane abstraction
+ used by the other control plane types.
+ - external: this control plane type represents an existing cluster that was not created by KubeFlex and is not the KubeFlex hosting cluster.
 
 ## Control Plane Backends
 
 KubeFlex roadmap aims to provide different types of backends: shared, dedicated, and for
-each type the ability to choose if etcd or sql. At this time only the following
-combinations are supported based on control plane type:
+each type the ability to choose etcd or SQL backends. At this time the following
+combinations are supported:
 
-- k8s: shared postgresql
-- ocm: dedicated etcd
+- k8s: shared PostgreSQL
 - vcluster: dedicated sqlite
+
+Note: OCM-specific backends are no longer emphasized in the primary docs; OCM-style federation scenarios should be implemented via integrations running on `vcluster` instances.
 
 ## Creating with a selected control plane type
 
@@ -372,13 +374,6 @@ To create a control plane of type `vcluster` run the command:
 ```shell
 kflex create cp2 --type vcluster
 ```
-
-To create a control plane of type `ocm` run the command:
-
-```shell
-kflex create cp3 --type ocm
-```
-
 To create a control plane of type `host` run the command:
 
 ```shell


### PR DESCRIPTION
Fixed #540

Remove OCM from the primary supported control plane lists in documentation (README, docs/architecture.md, docs/multi-tenancy.md, docs/users.md).
Clarify that OCM-style multi-cluster/federation workflows are supported by deploying integrations to vcluster instances.
Focus user-facing docs on the four main control plane types: k8s, vcluster, host, and external.
Files changed

[README.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — removed [ocm](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from Supported Control Plane Types and added a short note about vcluster.
[architecture.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — removed the OCM bullet and added a deprecation/clarification pointing to vcluster integrations.
[multi-tenancy.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — removed Open Cluster Management as a primary integration and updated the edge/multi-cluster section to reference vcluster + integrations.
[users.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — removed OCM items from Control Plane Types and Backends, removed the kflex create --type ocm example, and added notes directing readers to vcluster for federation-like functionality.
Rationale

OCM remains a code/CRD/test-level artifact in the repo (CRD enums, controller code and e2e tests). These changes intentionally update user-facing documentation only, without removing runtime or API support for OCM. This avoids breaking CRDs or controller behavior while aligning docs with the current recommended usage.
Pointing users to vcluster for OCM-style workflows encourages a consistent approach for multi-cluster/federation use cases while preserving existing code paths for compatibility.
Follow-ups (suggested)


