### PR TITLE
:seedling: Add kubeflex directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ dist/
 
 .vscode/
 
-kubeflex
+/kubeflex/


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds kubeflex directory created after running [install-kubeflex.sh](https://github.com/kubestellar/kubeflex/blob/main/scripts/install-kubeflex.sh) script to **.gitignore**

## Related issue(s)

Fixes #568
