### PR TITLE
🐛 Restore stripping of leading "v" from container image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ undeploy: ## Undeploy manager from the K8s cluster specified in ~/.kube/config. 
 
 .PHONY: chart
 chart: manifests kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(shell echo ${IMG} | sed 's/\(:.*\)v/\1/')
 	$(KUSTOMIZE) build config/default > chart/templates/operator.yaml
 	@cat config/samples/postcreate-hooks/openshift-crds.yaml > /tmp/hooks.yaml
 	@kubectl create secret generic postcreate-hooks -n kubeflex-system --from-file=/tmp/hooks.yaml --dry-run=client --output=yaml > chart/templates/builtin-hooks.yaml


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR restores the stripping of a leading "v" from the image tag in the Makefile target `chart`.

This is needed because .github/workflows/goreleaser.yml says

```shell
        make chart IMG=${{ env.REGISTRY }}/${{ env.OPERATOR_IMAGE }}:${{github.ref_name}}
```

and the tag has a leading "v" but the controller-manager container image tag does not.

This stripping was erroneously removed in #519 .

## Related issue(s)

This takes a step towards resolving #588; that Issue will not be fully resolved until a new release is made.
