### PR TITLE
🐛 :  helm chart controller manager image reference fixed 

### DIFF
--- a/chart/templates/operator.yaml
+++ b/chart/templates/operator.yaml
@@ -619,7 +619,7 @@ spec:
           value: /tmp
         - name: HELM_CACHE_HOME
           value: /tmp
-        image: <placeholder>
+        image: ghcr.io/kubestellar/kubeflex/manager:{{ trimPrefix "v" .Chart.Version }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION

## Summary
The `kubeflex-operator` Helm chart constructs the controller manager image tag directly from `.Chart.Version`.
In `v0.9.2`, this results in the chart referencing `ghcr.io/kubestellar/kubeflex/manager:v0.9.`2, but the published images are tagged without the v prefix (e.g. 0.9.2).

This causes fresh installs and CI jobs to fail with `ImagePullBackOff.`

Root Cause

Chart version includes a leading v (e.g. v0.9.2)

Kubeflex manager images are published without the v prefix

The Helm template did not normalize the version before constructing the image tag
this fixes the problem in #588 .  
<img width="796" height="174" alt="Screenshot 2025-12-16 000249" src="https://github.com/user-attachments/assets/ab27bbb4-2594-4b6b-a53d-b51ad1ecffe3" />
Helm renders the image tag from `.Chart.Version`. Locally the chart version is 0.1.0, so the rendered image tag is `0.1.0`. When released as `v0.9.2`, the rendered tag will correctly be `0.9.2`.
This PR fixes a Helm templating bug. Chart versioning and release tagging should be handled as part of the release process, not within a bugfix PR.


## Related issue [kubestellar/kubestellar#3574](https://github.com/kubestellar/kubestellar/pull/3574)


