### PR TITLE
✨ : made changes to ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,3 +21,24 @@ jobs:
         run: go build -v ./...
       - name: Test
         run: go test -v ./...
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+      - name: Generate and validate Helm chart
+        run: |
+          make chart
+          helm template test ./chart > /tmp/rendered.yaml
+          echo "Rendered images:"
+          grep "image:" /tmp/rendered.yaml
+      - name: Guard against invalid image tags
+        run: |
+         grep -E "image: .*kubeflex/manager:v[0-9]" /tmp/rendered.yaml && {
+            echo "ERROR: kubeflex manager image uses v-prefixed tag";
+            exit 1;
+          } || true
+          fi
+
+            
+  
+
+
+


### PR DESCRIPTION

-->
## Summary
The kubeflex-operator Helm chart is generated during the release process via make chart. This path is not exercised by PR CI, so regressions introduced in release-only logic can ship undetected.

This is what happened in #588  : an incorrect manager image tag was generated during chart creation and was not caught by CI, impacting downstream consumers. The gap is described in #589 .

This PR extends PR CI to:

run make chart

render the generated Helm chart using helm template

validate that the kubeflex manager image does not use a v-prefixed tag

The check is intentionally narrow and only targets the kubeflex manager image, avoiding false positives from third-party images.

## Related issue(s)
#588 

Fixes # 
#589 
