### PR TITLE
✨ Add issue triage workflow and /triage-accepted command

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   label-on-comment:
-    if: github.event.comment.body == '/help-wanted' || github.event.comment.body == '/good-first-issue'
+    if: github.event.comment.body == '/help-wanted' || github.event.comment.body == '/good-first-issue' || github.event.comment.body == '/triage-accepted' 
     runs-on: ubuntu-latest
     steps:
       - name: Add label based on comment
@@ -20,6 +20,25 @@ jobs:
             const issue_number = context.payload.issue.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            if (comment === '/triage accepted') {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name: 'need-triage',
+                });
+              } catch (_) {
+                // ignore if label does not exist
+              }
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: ['triage-accepted'],
+              });
+              return;
+            }
 
             let label = null;
             if (comment === '/help-wanted') {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Your assistance in improving documentation is highly valued, regardless of your 
 
 To claim an issue that you are interested in, kindly leave a comment on the issue and request the maintainers to assign it to you.
 
+
+
 ### Committing
 We encourage all contributors to adopt [best practices in git commit management](https://www.futurelearn.com/info/blog/telling-stories-with-your-git-history) to facilitate efficient reviews and retrospective analysis. Your git commits should provide ample context for reviewers and future codebase readers.
 


### PR DESCRIPTION
### What this PR does
- Introduces a simple issue triage workflow using labels
- Adds a `/triage-accepted` slash command to mark issues as reviewed
- Automatically transitions issues from `need-triage` → `triage-accepted`
- Documents the triage process for contributors and maintainers

### Why this is needed
- Improves visibility into issue review status
- Reduces ambiguity for contributors
- Keeps issue management consistent and lightweight



#614 
