### PR TITLE
ci: skip pr-verifier for dependabot PRs

### DIFF
--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -1,16 +1,14 @@
 name: pr-verifier
 
 on:
-  # NB: using `pull_request_target` runs this in the context of
-  # the base repository, so it has permission to upload to the checks API.
-  # This means changes won't kick in to this file until merged onto the
-  # main branch.
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 jobs:
   verify-pr:
     name: verify PR contents
+    # Skip verification for dependabot PRs - they use different title conventions
+    if: github.actor != 'dependabot[bot]'
     permissions:
       checks: write
       pull-requests: read


### PR DESCRIPTION
Skip PR title verification for dependabot PRs since they use different title conventions (deps:, ci:) than the expected emoji prefixes.