### PR TITLE
fix: update Dockerfile to use Go 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
Update Dockerfile to use Go 1.24 to match the go.mod requirement.

## Details
The go.mod requires Go 1.24.5 but the Dockerfile was using Go 1.19, causing image builds to fail.

## Test plan
- [ ] Verify Container Image Scanning workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)