### PR TITLE
🐛 fix: Add pkg/ directory to Dockerfile for build to succeed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY cmd/manager/main.go cmd/manager/main.go
 COPY api/ api/
 COPY internal/controller/ internal/controller/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command


### PR DESCRIPTION
## Summary
- Add missing `pkg/` directory to Dockerfile
- The controller imports packages from `pkg/reconcilers/*` and `pkg/util` which were not being copied into the Docker image

## Test plan
- [ ] Verify Container Image Scanning workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)