### PR TITLE
🐛 Make goreleaser use high enough release of Go

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
       with:
-        go-version: v1.23
+        go-version: v1.24
 
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -66,6 +66,10 @@ LATEST_TAG=<tag used for image> make ko-build-push-cmupdate
 
 1. Delete branch "brew" from https://github.com/kubestellar/kubeflex, if there is such a branch.
 
+1. Make sure that the `go-version` parameter of `actions/setup-go` in
+   `.github/workflows/goreleaser.yml` is high enough. It is enough
+   that its minor version is not below the one in `go.mod`.
+
 1. `git checkout main` and make sure it (a) equals `main` in https://github.com/kubestellar/kubeflex and (b) is what you want to release.
 
 1. check existing tags e.g.,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates `.github/workflows/goreleaser.yml` to specify a high enough release of Go in the setup step, and also updates the release-making instructions to include a check for this.

## Related issue(s)

Fixes #
