### PR TITLE
🌱 Remove inactive maintainer from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,4 +4,3 @@ approvers:
   - clubanderson
   - dumb0002
   - waltforme
-  - rxinui


### PR DESCRIPTION
## Summary
Remove rxinui from OWNERS - no longer in good standing per maintainer metrics.

## Test plan
- [x] OWNERS file syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)