### PR TITLE
📖 docs: add cross-reference from users.md to k3d.md

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -70,6 +70,8 @@ kflex init
 
 ### Installing on k3d
 
+For a complete guide to using KubeFlex with k3d, including prerequisites, cluster setup, and control plane creation, see the [k3d documentation](./k3d.md).
+
 These steps have only been tested with k3d v5.6.0. Create a k3d cluster with `traefik` disabled and nginx ingress as follows:
 
 ```shell


### PR DESCRIPTION
## Summary
Adds a cross-reference link in the "Installing on k3d" section of 
`docs/users.md` pointing to the dedicated `docs/k3d.md` guide.

## Problem
Users who find the brief k3d section in `users.md` have no way to 
discover the full k3d documentation page added in PR #676.

## Changes
- Added one line in `docs/users.md` under `### Installing on k3d` 
  linking to `./k3d.md` for the complete setup guide.

Closes #677