### PR TITLE
test(e2e): add support for testing in k3d clusters

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -25,13 +25,9 @@ on:
       - "v*"
 
 jobs:
-  test-controlplane-lifecycle-management:
-    name: Test ControlPlane lifecycle management (${{ matrix.cluster-type }})
+  test-on-kind:
+    name: E2E test on kind
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        cluster-type: [kind, k3d]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -44,15 +40,6 @@ jobs:
 
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
-      - name: Install k3d
-        if: matrix.cluster-type == 'k3d'
-        run: |
-          K3D_VERSION=v5.8.3
-          curl -sL "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64" -o k3d
-          chmod +x k3d
-          sudo mv k3d /usr/local/bin/k3d
-          k3d version
-
       - name: Install kubectl
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
         id: install
@@ -60,10 +47,11 @@ jobs:
       - name: Run test
         run: |
           if [ -n "${{ inputs.release }}" ]; then
-            test/e2e/run.sh --cluster-type ${{ matrix.cluster-type }} --release "${{ inputs.release }}"
+             test/e2e/run.sh --release ${{ inputs.release }}
           else
-            test/e2e/run.sh --cluster-type ${{ matrix.cluster-type }}
+             test/e2e/run.sh
           fi
+
       - name: Examine GitHub rate limit
         run: curl https://api.github.com/rate_limit
 
@@ -86,3 +74,56 @@ jobs:
       - name: Show logs of the KubeFlex operator
         if: always()
         run: kubectl --context kind-kubeflex -n kubeflex-system logs job/kubeflex-operator
+
+  test-on-k3d:
+    name: E2E test on k3d
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version: v1.24.5
+          cache: true
+
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
+        id: install
+
+      - name: Install k3d
+        run: bash <(curl -sSL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh)
+
+      - name: Run test
+        run: |
+          if [ -n "${{ inputs.release }}" ]; then
+             test/e2e/run.sh --platform k3d --release ${{ inputs.release }}
+          else
+             test/e2e/run.sh --platform k3d
+          fi
+
+      - name: Examine GitHub rate limit
+        run: curl https://api.github.com/rate_limit
+
+      - name: Show kubeconfig contexts
+        if: always()
+        run: kubectl config get-contexts
+
+      - name: Show running components of KubeFlex
+        if: always()
+        run: kubectl --context k3d-kubeflex -n kubeflex-system get all
+
+      - name: Show logs of the KubeFlex controller manager
+        if: always()
+        run: kubectl --context k3d-kubeflex -n kubeflex-system logs deploy/kubeflex-controller-manager
+
+      - name: Show logs of the shared Postgres DB
+        if: always()
+        run: kubectl --context k3d-kubeflex -n kubeflex-system logs sts/postgres-postgresql
+
+      - name: Show logs of the KubeFlex operator
+        if: always()
+        run: kubectl --context k3d-kubeflex -n kubeflex-system logs job/kubeflex-operator

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -25,59 +25,13 @@ on:
       - "v*"
 
 jobs:
-  test-on-kind:
-    name: E2E test on kind
+  test-controlplane-lifecycle-management:
+    name: E2E test on ${{ matrix.cluster-type }}
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
-        with:
-          go-version: v1.24.5
-          cache: true
-
-      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
-
-      - name: Install kubectl
-        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
-        id: install
-
-      - name: Run test
-        run: |
-          if [ -n "${{ inputs.release }}" ]; then
-             test/e2e/run.sh --release ${{ inputs.release }}
-          else
-             test/e2e/run.sh
-          fi
-
-      - name: Examine GitHub rate limit
-        run: curl https://api.github.com/rate_limit
-
-      - name: Show kubeconfig contexts
-        if: always()
-        run: kubectl config get-contexts
-
-      - name: Show running components of KubeFlex
-        if: always()
-        run: kubectl --context kind-kubeflex -n kubeflex-system get all
-
-      - name: Show logs of the KubeFlex controller manager
-        if: always()
-        run: kubectl --context kind-kubeflex -n kubeflex-system logs deploy/kubeflex-controller-manager
-
-      - name: Show logs of the shared Postgres DB
-        if: always()
-        run: kubectl --context kind-kubeflex -n kubeflex-system logs sts/postgres-postgresql
-
-      - name: Show logs of the KubeFlex operator
-        if: always()
-        run: kubectl --context kind-kubeflex -n kubeflex-system logs job/kubeflex-operator
-
-  test-on-k3d:
-    name: E2E test on k3d
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster-type: [kind, k3d]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -95,14 +49,15 @@ jobs:
         id: install
 
       - name: Install k3d
+        if: matrix.cluster-type == 'k3d'
         run: bash <(curl -sSL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh)
 
       - name: Run test
         run: |
           if [ -n "${{ inputs.release }}" ]; then
-             test/e2e/run.sh --platform k3d --release ${{ inputs.release }}
+             test/e2e/run.sh --cluster-type ${{ matrix.cluster-type }} --release ${{ inputs.release }}
           else
-             test/e2e/run.sh --platform k3d
+             test/e2e/run.sh --cluster-type ${{ matrix.cluster-type }}
           fi
 
       - name: Examine GitHub rate limit
@@ -114,16 +69,16 @@ jobs:
 
       - name: Show running components of KubeFlex
         if: always()
-        run: kubectl --context k3d-kubeflex -n kubeflex-system get all
+        run: kubectl --context ${{ matrix.cluster-type }}-kubeflex -n kubeflex-system get all
 
       - name: Show logs of the KubeFlex controller manager
         if: always()
-        run: kubectl --context k3d-kubeflex -n kubeflex-system logs deploy/kubeflex-controller-manager
+        run: kubectl --context ${{ matrix.cluster-type }}-kubeflex -n kubeflex-system logs deploy/kubeflex-controller-manager
 
       - name: Show logs of the shared Postgres DB
         if: always()
-        run: kubectl --context k3d-kubeflex -n kubeflex-system logs sts/postgres-postgresql
+        run: kubectl --context ${{ matrix.cluster-type }}-kubeflex -n kubeflex-system logs sts/postgres-postgresql
 
       - name: Show logs of the KubeFlex operator
         if: always()
-        run: kubectl --context k3d-kubeflex -n kubeflex-system logs job/kubeflex-operator
+        run: kubectl --context ${{ matrix.cluster-type }}-kubeflex -n kubeflex-system logs job/kubeflex-operator

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -26,8 +26,12 @@ on:
 
 jobs:
   test-controlplane-lifecycle-management:
-    name: Test ControlPlane lifecycle management
+    name: Test ControlPlane lifecycle management (${{ matrix.cluster-type }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster-type: [kind, k3d]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -40,6 +44,15 @@ jobs:
 
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
+      - name: Install k3d
+        if: matrix.cluster-type == 'k3d'
+        run: |
+          K3D_VERSION=v5.8.3
+          curl -sL "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64" -o k3d
+          chmod +x k3d
+          sudo mv k3d /usr/local/bin/k3d
+          k3d version
+
       - name: Install kubectl
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d
         id: install
@@ -47,10 +60,10 @@ jobs:
       - name: Run test
         run: |
           if [ -n "${{ inputs.release }}" ]; then
-             test/e2e/run.sh --release ${{ inputs.release }}
+            test/e2e/run.sh --cluster-type ${{ matrix.cluster-type }} --release "${{ inputs.release }}"
           else
-             test/e2e/run.sh
-          fi    
+            test/e2e/run.sh --cluster-type ${{ matrix.cluster-type }}
+          fi
       - name: Examine GitHub rate limit
         run: curl https://api.github.com/rate_limit
 

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,19 @@ ko-build-local-cmupdate: test
 
 .PHONY: kind-load-cmupdate-image
 kind-load-cmupdate-image:
-	kind load docker-image ko.local/cmupdate:${LATEST_TAG} --name kubeflex
+	@if kind get clusters 2>/dev/null | grep -q "^kubeflex$$"; then \
+		echo "Loading cmupdate image into kind cluster..."; \
+		kind load docker-image ko.local/cmupdate:${LATEST_TAG} --name kubeflex; \
+	elif command -v k3d > /dev/null 2>&1 && k3d cluster get kubeflex > /dev/null 2>&1; then \
+		echo "Loading cmupdate image into k3d cluster..."; \
+		k3d image import ko.local/cmupdate:${LATEST_TAG} --cluster kubeflex; \
+	elif ! command -v k3d > /dev/null 2>&1; then \
+		echo "Error: k3d is not installed and no kind cluster named 'kubeflex' found."; \
+		exit 1; \
+	else \
+		echo "Error: no kind or k3d cluster named 'kubeflex' found."; \
+		exit 1; \
+	fi
 
 .PHONY: ko-build-push-cmupdate
 ko-build-push-cmupdate: test ## Build and push container image with ko
@@ -215,7 +227,19 @@ ko-local-build:
 # this is used for local testing
 .PHONY: kind-load-image
 kind-load-image: ko-local-build
-	kind load docker-image ${IMG} --name kubeflex
+	@if kind get clusters 2>/dev/null | grep -q "^kubeflex$$"; then \
+		echo "Loading image into kind cluster..."; \
+		kind load docker-image ${IMG} --name kubeflex; \
+	elif command -v k3d > /dev/null 2>&1 && k3d cluster get kubeflex > /dev/null 2>&1; then \
+		echo "Loading image into k3d cluster..."; \
+		k3d image import ${IMG} --cluster kubeflex; \
+	elif ! command -v k3d > /dev/null 2>&1; then \
+		echo "Error: k3d is not installed and no kind cluster named 'kubeflex' found."; \
+		exit 1; \
+	else \
+		echo "Error: no kind or k3d cluster named 'kubeflex' found."; \
+		exit 1; \
+	fi
 
 .PHONY: install-local-chart
 install-local-chart: chart kind-load-image

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ KO_DOCKER_REPO = ko.local
 IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
 CMD_NAME ?= manager
 IMG ?= ${KO_DOCKER_REPO}/${CMD_NAME}:${IMAGE_TAG}
+TEST_HOST ?= kind
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26.1
@@ -224,25 +225,18 @@ chart: manifests kustomize
 ko-local-build:
 	KO_DOCKER_REPO=${KO_DOCKER_REPO} ko build -B ./cmd/${CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
 
-# this is used for local testing
+# The following are used for local testing
+
 .PHONY: kind-load-image
 kind-load-image: ko-local-build
-	@if kind get clusters 2>/dev/null | grep -q "^kubeflex$$"; then \
-		echo "Loading image into kind cluster..."; \
-		kind load docker-image ${IMG} --name kubeflex; \
-	elif command -v k3d > /dev/null 2>&1 && k3d cluster get kubeflex > /dev/null 2>&1; then \
-		echo "Loading image into k3d cluster..."; \
-		k3d image import ${IMG} --cluster kubeflex; \
-	elif ! command -v k3d > /dev/null 2>&1; then \
-		echo "Error: k3d is not installed and no kind cluster named 'kubeflex' found."; \
-		exit 1; \
-	else \
-		echo "Error: no kind or k3d cluster named 'kubeflex' found."; \
-		exit 1; \
-	fi
+	kind load docker-image ${IMG} --name kubeflex
+
+.PHONY: k3d-load-image
+k3d-load-image: ko-local-build
+	k3d image import ${IMG} --cluster kubeflex
 
 .PHONY: install-local-chart
-install-local-chart: chart kind-load-image
+install-local-chart: chart ${TEST_HOST}-load-image
 	helm upgrade --install kubeflex-operator ./chart
 
 ##@ Build Dependencies

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -5,14 +5,16 @@ The end-to-end test suite can be used manually by a contributor and also is used
 The end-to-end test suite can either test the local sources or a given release.
 
 ## Prerequisites
-`kind`,`jq` and  `kubectl` are required to run the test.
+`helm`,`jq` and  `kubectl` are required to run the test.
+Also, either `kind` or `k3d`, depending on the sort of host cluster chosen.
 
 ## Run E2E tests manually
 
-From the root directory of this git repository, you can run any of the following commands.
+From the root directory of this git repository, you can run any of the following commands. The `--platform` and `--release` options combine orthogonally.
 
 ```shell
-test/e2e/run.sh   # Run E2E tests against local source
+test/e2e/run.sh   # Run E2E tests against local source in kind cluster
 test/e2e/run.sh --release latest   # Run E2E tests against the latest released version
-test/e2e/run.sh --release v0.9.1     # Run E2E tests against a specific release
+test/e2e/run.sh --release v0.9.1   # Run E2E tests against a specific release
+test/e2e/run.sh --platform k3d     # Run E2E tests against local source in k3d cluster
 ```

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -10,11 +10,11 @@ Also, either `kind` or `k3d`, depending on the sort of host cluster chosen.
 
 ## Run E2E tests manually
 
-From the root directory of this git repository, you can run any of the following commands. The `--platform` and `--release` options combine orthogonally.
+From the root directory of this git repository, you can run any of the following commands. The `--cluster-type` and `--release` options combine orthogonally.
 
 ```shell
 test/e2e/run.sh   # Run E2E tests against local source in kind cluster
 test/e2e/run.sh --release latest   # Run E2E tests against the latest released version
 test/e2e/run.sh --release v0.9.1   # Run E2E tests against a specific release
-test/e2e/run.sh --platform k3d     # Run E2E tests against local source in k3d cluster
+test/e2e/run.sh --cluster-type k3d     # Run E2E tests against local source in k3d cluster
 ```

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -21,9 +21,10 @@ set -x # echo so that users can understand what is happening
 :
 kubectl config delete-context kind-kubeflex 2>&1 || true
 kubectl config delete-context kind-ext &> /dev/null 2>&1 || true
+kubectl config delete-context k3d-kubeflex 2>&1 || true
+kubectl config delete-context k3d-ext &> /dev/null 2>&1 || true
 kubectl config delete-context cp1 &> /dev/null 2>&1 || true
 kubectl config delete-context cp2 &> /dev/null 2>&1 || true
 kind delete cluster --name kubeflex >/dev/null 2>&1 || true
 kind delete cluster --name ext >/dev/null 2>&1 || true
-k3d cluster delete kubeflex >/dev/null 2>&1 || true
-k3d cluster delete ext >/dev/null 2>&1 || true
+k3d cluster delete kubeflex ext >/dev/null 2>&1 || true

--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -25,3 +25,5 @@ kubectl config delete-context cp1 &> /dev/null 2>&1 || true
 kubectl config delete-context cp2 &> /dev/null 2>&1 || true
 kind delete cluster --name kubeflex >/dev/null 2>&1 || true
 kind delete cluster --name ext >/dev/null 2>&1 || true
+k3d cluster delete kubeflex >/dev/null 2>&1 || true
+k3d cluster delete ext >/dev/null 2>&1 || true

--- a/test/e2e/manage-type-external.sh
+++ b/test/e2e/manage-type-external.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Currently this only works when testing with a host cluster made by `kind`.
-platform="kind"
+cluster_type="kind"
 
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source "${SRC_DIR}/setup-shell.sh"
@@ -22,7 +22,7 @@ source "${SRC_DIR}/setup-shell.sh"
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 
-host_context="${platform}-kubeflex"
+host_context="${cluster_type}-kubeflex"
 EXT_CLUSTER_NAME=ext
 
 :
@@ -35,7 +35,7 @@ kubectl --context "$host_context" apply -f ${SRC_DIR}/list-controller-pch.yaml
 : -------------------------------------------------------------------------
 : Create an external cluster to be adopted
 :
-if [ "$platform" == kind ]; then
+if [ "$cluster_type" == kind ]; then
     kind create cluster --name ${EXT_CLUSTER_NAME}
     override_endpoint="${EXT_CLUSTER_NAME}-control-plane:6443"
 else
@@ -48,7 +48,7 @@ fi
 : Create a ControlPlane of type external
 :
 
-./bin/kflex adopt --adopted-context "${platform}-${EXT_CLUSTER_NAME}" --url-override "https://${override_endpoint}" ${EXT_CLUSTER_NAME} --postcreate-hook list-controller --chatty-status=false
+./bin/kflex adopt --adopted-context "${cluster_type}-${EXT_CLUSTER_NAME}" --url-override "https://${override_endpoint}" ${EXT_CLUSTER_NAME} --postcreate-hook list-controller --chatty-status=false
 
 :
 : -------------------------------------------------------------------------

--- a/test/e2e/manage-type-external.sh
+++ b/test/e2e/manage-type-external.sh
@@ -20,6 +20,28 @@ set -x # echo so that users can understand what is happening
 set -e # exit on error
 
 EXT_CLUSTER_NAME=ext
+cluster_type="kind"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cluster-type)
+      if (( $# < 2 )); then
+        echo "Error: --cluster-type requires a value (kind or k3d)" >&2
+        exit 1
+      fi
+      cluster_type="$2"
+      if [[ "${cluster_type}" != "kind" && "${cluster_type}" != "k3d" ]]; then
+        echo "Error: --cluster-type must be 'kind' or 'k3d', got '${cluster_type}'" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done 
 
 :
 : -------------------------------------------------------------------------
@@ -29,16 +51,16 @@ kubectl --context kind-kubeflex apply -f ${SRC_DIR}/list-controller-pch.yaml
 
 :
 : -------------------------------------------------------------------------
-: Create an external cluster to be adopted
+: Create an external cluster to be adopted and adopt it
 :
-kind create cluster --name ${EXT_CLUSTER_NAME}
-
-:
-: -------------------------------------------------------------------------
-: Create a ControlPlane of type external
-:
-
-./bin/kflex adopt --adopted-context kind-${EXT_CLUSTER_NAME} --url-override https://${EXT_CLUSTER_NAME}-control-plane:6443 ${EXT_CLUSTER_NAME} --postcreate-hook list-controller --chatty-status=false
+if [[ "${cluster_type}" == "k3d" ]]; then
+    k3d cluster create ${EXT_CLUSTER_NAME} --network k3d-kubeflex
+    kubectl config rename-context k3d-${EXT_CLUSTER_NAME} kind-${EXT_CLUSTER_NAME} || true
+    ./bin/kflex adopt --adopted-context kind-${EXT_CLUSTER_NAME} --url-override https://k3d-${EXT_CLUSTER_NAME}-server-0:6443 ${EXT_CLUSTER_NAME} --postcreate-hook list-controller --chatty-status=false
+else
+    kind create cluster --name ${EXT_CLUSTER_NAME}
+    ./bin/kflex adopt --adopted-context kind-${EXT_CLUSTER_NAME} --url-override https://${EXT_CLUSTER_NAME}-control-plane:6443 ${EXT_CLUSTER_NAME} --postcreate-hook list-controller --chatty-status=false
+fi
 
 :
 : -------------------------------------------------------------------------

--- a/test/e2e/manage-type-external.sh
+++ b/test/e2e/manage-type-external.sh
@@ -13,71 +13,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Currently this only works when testing with a host cluster made by `kind`.
+platform="kind"
+
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source "${SRC_DIR}/setup-shell.sh"
 
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 
+host_context="${platform}-kubeflex"
 EXT_CLUSTER_NAME=ext
-cluster_type="kind"
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --cluster-type)
-      if (( $# < 2 )); then
-        echo "Error: --cluster-type requires a value (kind or k3d)" >&2
-        exit 1
-      fi
-      cluster_type="$2"
-      if [[ "${cluster_type}" != "kind" && "${cluster_type}" != "k3d" ]]; then
-        echo "Error: --cluster-type must be 'kind' or 'k3d', got '${cluster_type}'" >&2
-        exit 1
-      fi
-      shift 2
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      exit 1
-      ;;
-  esac
-done 
 
 :
 : -------------------------------------------------------------------------
 : Define a post-create-hook for testing
 :
-kubectl --context kind-kubeflex apply -f ${SRC_DIR}/list-controller-pch.yaml
+kubectl --context "$host_context" apply -f ${SRC_DIR}/list-controller-pch.yaml
 
 :
 : -------------------------------------------------------------------------
-: Create an external cluster to be adopted and adopt it
+: Create an external cluster to be adopted
 :
-if [[ "${cluster_type}" == "k3d" ]]; then
-    k3d cluster create ${EXT_CLUSTER_NAME} --network k3d-kubeflex
-    kubectl config rename-context k3d-${EXT_CLUSTER_NAME} kind-${EXT_CLUSTER_NAME} || true
-    ./bin/kflex adopt --adopted-context kind-${EXT_CLUSTER_NAME} --url-override https://k3d-${EXT_CLUSTER_NAME}-server-0:6443 ${EXT_CLUSTER_NAME} --postcreate-hook list-controller --chatty-status=false
-else
+if [ "$platform" == kind ]; then
     kind create cluster --name ${EXT_CLUSTER_NAME}
-    ./bin/kflex adopt --adopted-context kind-${EXT_CLUSTER_NAME} --url-override https://${EXT_CLUSTER_NAME}-control-plane:6443 ${EXT_CLUSTER_NAME} --postcreate-hook list-controller --chatty-status=false
+    override_endpoint="${EXT_CLUSTER_NAME}-control-plane:6443"
+else
+    k3d cluster create --image rancher/k3s:v1.32.13-k3s1 -p "10443:443@loadbalancer" --k3s-arg "--disable=traefik@server:*" ${EXT_CLUSTER_NAME}
+    override_endpoint="k3d-${EXT_CLUSTER_NAME}-server-0:6443"
 fi
+
+:
+: -------------------------------------------------------------------------
+: Create a ControlPlane of type external
+:
+
+./bin/kflex adopt --adopted-context "${platform}-${EXT_CLUSTER_NAME}" --url-override "https://${override_endpoint}" ${EXT_CLUSTER_NAME} --postcreate-hook list-controller --chatty-status=false
 
 :
 : -------------------------------------------------------------------------
 : Wait for adopted cluster secret to be created
 :
-wait-for-secret kind-kubeflex ${EXT_CLUSTER_NAME}-system admin-kubeconfig
+wait-for-secret "$host_context" ${EXT_CLUSTER_NAME}-system admin-kubeconfig
 
 :
 : -------------------------------------------------------------------------
 : Wait for test controller pod installed by pch to be running
 :
 
-kubectl --context kind-kubeflex -n ${EXT_CLUSTER_NAME}-system wait --for=condition=Ready pod list-controller
+kubectl --context "$host_context" -n ${EXT_CLUSTER_NAME}-system wait --for=condition=Ready pod list-controller
 
 :
 : -------------------------------------------------------------------------
-: Delete ControlPlane 
+: Delete ControlPlane
 :
 ./bin/kflex delete ${EXT_CLUSTER_NAME} --chatty-status=false
 

--- a/test/e2e/manage-type-k3s.sh
+++ b/test/e2e/manage-type-k3s.sh
@@ -15,6 +15,24 @@
 
 set -x # echo so that users can understand what is happening
 set -e # exit on error
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host-context)
+      host_context="$2"
+      shift 2 ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$host_context" ]; then
+    echo $0: Host context must be defined, by '--host-context' option or host_context environment variable >&2
+    exit 1
+fi
+
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source "${SRC_DIR}/setup-shell.sh"
 
@@ -54,9 +72,9 @@ echo "SUCCESS: Kubeconfig extensions verified for control plane $CP_NAME"
 : -------------------------------------------------------------------------
 : Wait for the running component of ControlPlane $CP_NAME to be ready/completed
 :
-kubectl --context kind-kubeflex -n $CP_NAME-system wait --for=jsonpath='{.status.availableReplicas}'=1 statefulset/k3s-server --timeout=120s
-kubectl --context kind-kubeflex -n $CP_NAME-system wait --for=condition=Complete job/k3s-bootstrap-kubeconfig --timeout=120s
-kubectl --context kind-kubeflex -n $CP_NAME-system wait --for=jsonpath='{.status.conditions[?(@.type == "Ready")]}' cps/$CP_NAME --timeout=120s
+kubectl --context "$host_context" -n $CP_NAME-system wait --for=jsonpath='{.status.availableReplicas}'=1 statefulset/k3s-server --timeout=120s
+kubectl --context "$host_context" -n $CP_NAME-system wait --for=condition=Complete job/k3s-bootstrap-kubeconfig --timeout=120s
+kubectl --context "$host_context" -n $CP_NAME-system wait --for=jsonpath='{.status.conditions[?(@.type == "Ready")]}' cps/$CP_NAME --timeout=120s
 
 : -------------------------------------------------------------------------
 : Create a Deployment in ControlPlane $CP_NAME, then wait for the Deployment

--- a/test/e2e/manage-type-k8s.sh
+++ b/test/e2e/manage-type-k8s.sh
@@ -16,6 +16,23 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host-context)
+      host_context="$2"
+      shift 2 ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$host_context" ]; then
+    echo $0: Host context must be defined, by '--host-context' option or host_context environment variable >&2
+    exit 1
+fi
+
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source "${SRC_DIR}/setup-shell.sh"
 
@@ -57,17 +74,17 @@ echo "SUCCESS: Kubeconfig extensions verified for control plane cp1"
 : Wait for the running components of ControlPlane cp1 to be ready, with
 : default timeout which is 30 seconds
 :
-kubectl --context kind-kubeflex -n cp1-system wait --for=condition=Available deployment/kube-apiserver
-kubectl --context kind-kubeflex -n cp1-system wait --for=condition=Available deployment/kube-controller-manager
+kubectl --context "$host_context" -n cp1-system wait --for=condition=Available deployment/kube-apiserver
+kubectl --context "$host_context" -n cp1-system wait --for=condition=Available deployment/kube-controller-manager
 
 :
 : -------------------------------------------------------------------------
 : Specify a PostCreateHook for cp1, then wait for the PostCreateHook to
 : take effect, with default timeout which is 30 seconds
 :
-kubectl --context kind-kubeflex patch cp/cp1 --type=merge --patch '{"spec":{"postCreateHook":"synthetic-crd"}}'
-wait-for-cmd 'kubectl --context kind-kubeflex get crd cr1s.synthetic-crd.com'
-kubectl --context kind-kubeflex wait --for=condition=Established crd cr1s.synthetic-crd.com
+kubectl --context "$host_context" patch cp/cp1 --type=merge --patch '{"spec":{"postCreateHook":"synthetic-crd"}}'
+wait-for-cmd 'kubectl --context "$host_context" get crd cr1s.synthetic-crd.com'
+kubectl --context "$host_context" wait --for=condition=Established crd cr1s.synthetic-crd.com
 
 :
 : -------------------------------------------------------------------------
@@ -87,7 +104,7 @@ kubectl --context cp1 wait --for=jsonpath='{.status.phase}'=Active ns/e2e --time
 : -------------------------------------------------------------------------
 : Test PostCreateHook kubeconfig access
 :
-${SRC_DIR}/test-kubeconfig-access.sh -t k8s
+${SRC_DIR}/test-kubeconfig-access.sh -t k8s --host-context "$host_context"
 
 :
 : -------------------------------------------------------------------------

--- a/test/e2e/manage-type-vcluster.sh
+++ b/test/e2e/manage-type-vcluster.sh
@@ -16,6 +16,23 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host-context)
+      host_context="$2"
+      shift 2 ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$host_context" ]; then
+    echo $0: Host context must be defined, by '--host-context' option or host_context environment variable >&2
+    exit 1
+fi
+
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source "${SRC_DIR}/setup-shell.sh"
 
@@ -56,8 +73,8 @@ echo "SUCCESS: Kubeconfig extensions verified for control plane cp2"
 : -------------------------------------------------------------------------
 : Wait for the running component of ControlPlane cp2 to be ready/completed
 :
-kubectl --context kind-kubeflex -n cp2-system wait --for=jsonpath='{.status.availableReplicas}'=1 statefulset/vcluster --timeout=120s
-kubectl --context kind-kubeflex -n cp2-system wait --for=condition=Complete job/update-cluster-info --timeout=120s
+kubectl --context "$host_context" -n cp2-system wait --for=jsonpath='{.status.availableReplicas}'=1 statefulset/vcluster --timeout=120s
+kubectl --context "$host_context" -n cp2-system wait --for=condition=Complete job/update-cluster-info --timeout=120s
 
 :
 : -------------------------------------------------------------------------
@@ -78,7 +95,7 @@ kubectl --context cp2 wait --for=condition=Available deploy/my-nginx --timeout=1
 : -------------------------------------------------------------------------
 : Test PostCreateHook in-cluster kubeconfig access
 :
-${SRC_DIR}/test-kubeconfig-access.sh -t vcluster
+${SRC_DIR}/test-kubeconfig-access.sh -t vcluster --host-context "$host_context"
 
 :
 : -------------------------------------------------------------------------

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -16,7 +16,7 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 release=""
-cluster_type="kind"
+platform=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -24,24 +24,20 @@ while [[ $# -gt 0 ]]; do
       release="$2"
       shift 2
       ;;
-    --cluster-type)
-      if (( $# < 2 )); then
-        echo "Error: --cluster-type requires a value (kind or k3d)" >&2
-        exit 1
-      fi
-      cluster_type="$2"
-      if [[ "${cluster_type}" != "kind" && "${cluster_type}" != "k3d" ]]; then
-        echo "Error: --cluster-type must be 'kind' or 'k3d', got '${cluster_type}'" >&2
-        exit 1
-      fi
+    --platform)
+      platform="$2"
       shift 2
       ;;
     *)
-      echo "Unknown argument: $1" >&2
+      echo "Unknown argument: $1"
       exit 1
       ;;
   esac
-done 
+done
+
+platform=${platform:-kind}
+host_context="${platform}-kubeflex"
+
 # Change to repository root directory to ensure scripts work from any location
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -58,7 +54,7 @@ echo "Running E2E tests from: ${PWD}"
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 
 ${SRC_DIR}/cleanup.sh
-${SRC_DIR}/setup-kubeflex.sh --cluster-type "${cluster_type}" --release "${release}"
+${SRC_DIR}/setup-kubeflex.sh --release "${release}" --platform "$platform"
 cfgfile="${KUBECONFIG:-$HOME/.kube/config}"
 if [[ "$(yq -o=json .extensions "$cfgfile" )" =~ ^[[] ]]; then
     yq '.extensions |= [ .[] | select(.name != "kubeflex") ]' "$cfgfile" > $$
@@ -72,16 +68,27 @@ else
     : there is no local watch-objs command, neither source nor executable, to use
 fi
 
-${SRC_DIR}/manage-type-k8s.sh
+${SRC_DIR}/manage-type-k8s.sh --host-context "$host_context"
 
 if [ -z "${release}" ]; then
     # This test is only appropriate when testing the local copy
-    ${SRC_DIR}/test-controller-image-update.sh
+    ${SRC_DIR}/test-controller-image-update.sh --platform "$platform"
 fi
 
-${SRC_DIR}/manage-type-vcluster.sh
-${SRC_DIR}/manage-type-external.sh --cluster-type "${cluster_type}"
-${SRC_DIR}/manage-ctx.sh
+${SRC_DIR}/manage-type-vcluster.sh --host-context "$host_context"
+
+case "$platform" in
+    (kind) ${SRC_DIR}/manage-type-external.sh ;;
+    (k3d)
+        echo -e "\n================================"
+        echo "External cluster adoption is not working when the host cluster is made by k3d"
+        echo -e "================================\n"
+        ;;
+    (*) echo "Unexpected platform '$platform' !" >&2
+        exit 1 ;;
+esac
+
+${SRC_DIR}/manage-ctx.sh --host-context "$host_context"
 ${SRC_DIR}/test-postcreate-completion.sh -t k8s
 ${SRC_DIR}/test-postcreate-completion.sh -t vcluster
 ${SRC_DIR}/test-postcreatehook-retry.sh -t k8s

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -16,7 +16,7 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 release=""
-platform=""
+cluster_type=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -24,8 +24,8 @@ while [[ $# -gt 0 ]]; do
       release="$2"
       shift 2
       ;;
-    --platform)
-      platform="$2"
+    --cluster-type)
+      cluster_type="$2"
       shift 2
       ;;
     *)
@@ -35,8 +35,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-platform=${platform:-kind}
-host_context="${platform}-kubeflex"
+cluster_type=${cluster_type:-kind}
+host_context="${cluster_type}-kubeflex"
 
 # Change to repository root directory to ensure scripts work from any location
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -54,7 +54,7 @@ echo "Running E2E tests from: ${PWD}"
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 
 ${SRC_DIR}/cleanup.sh
-${SRC_DIR}/setup-kubeflex.sh --release "${release}" --platform "$platform"
+${SRC_DIR}/setup-kubeflex.sh --release "${release}" --cluster-type "$cluster_type"
 cfgfile="${KUBECONFIG:-$HOME/.kube/config}"
 if [[ "$(yq -o=json .extensions "$cfgfile" )" =~ ^[[] ]]; then
     yq '.extensions |= [ .[] | select(.name != "kubeflex") ]' "$cfgfile" > $$
@@ -72,19 +72,19 @@ ${SRC_DIR}/manage-type-k8s.sh --host-context "$host_context"
 
 if [ -z "${release}" ]; then
     # This test is only appropriate when testing the local copy
-    ${SRC_DIR}/test-controller-image-update.sh --platform "$platform"
+    ${SRC_DIR}/test-controller-image-update.sh --cluster-type "$cluster_type"
 fi
 
 ${SRC_DIR}/manage-type-vcluster.sh --host-context "$host_context"
 
-case "$platform" in
+case "$cluster_type" in
     (kind) ${SRC_DIR}/manage-type-external.sh ;;
     (k3d)
         echo -e "\n================================"
         echo "External cluster adoption is not working when the host cluster is made by k3d"
         echo -e "================================\n"
         ;;
-    (*) echo "Unexpected platform '$platform' !" >&2
+    (*) echo "Unexpected cluster_type '$cluster_type' !" >&2
         exit 1 ;;
 esac
 

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -16,6 +16,7 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 release=""
+cluster_type="kind"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -23,8 +24,20 @@ while [[ $# -gt 0 ]]; do
       release="$2"
       shift 2
       ;;
+    --cluster-type)
+      if (( $# < 2 )); then
+        echo "Error: --cluster-type requires a value (kind or k3d)" >&2
+        exit 1
+      fi
+      cluster_type="$2"
+      if [[ "${cluster_type}" != "kind" && "${cluster_type}" != "k3d" ]]; then
+        echo "Error: --cluster-type must be 'kind' or 'k3d', got '${cluster_type}'" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
     *)
-      echo "Unknown argument: $1"
+      echo "Unknown argument: $1" >&2
       exit 1
       ;;
   esac
@@ -45,7 +58,7 @@ echo "Running E2E tests from: ${PWD}"
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 
 ${SRC_DIR}/cleanup.sh
-${SRC_DIR}/setup-kubeflex.sh --release "${release}"
+${SRC_DIR}/setup-kubeflex.sh --cluster-type "${cluster_type}" --release "${release}"
 cfgfile="${KUBECONFIG:-$HOME/.kube/config}"
 if [[ "$(yq -o=json .extensions "$cfgfile" )" =~ ^[[] ]]; then
     yq '.extensions |= [ .[] | select(.name != "kubeflex") ]' "$cfgfile" > $$
@@ -67,7 +80,7 @@ if [ -z "${release}" ]; then
 fi
 
 ${SRC_DIR}/manage-type-vcluster.sh
-${SRC_DIR}/manage-type-external.sh
+${SRC_DIR}/manage-type-external.sh --cluster-type "${cluster_type}"
 ${SRC_DIR}/manage-ctx.sh
 ${SRC_DIR}/test-postcreate-completion.sh -t k8s
 ${SRC_DIR}/test-postcreate-completion.sh -t vcluster

--- a/test/e2e/setup-kubeflex.sh
+++ b/test/e2e/setup-kubeflex.sh
@@ -16,7 +16,7 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 release=""
-platform=""
+cluster_type=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --release)
@@ -27,12 +27,12 @@ while [[ $# -gt 0 ]]; do
       release="$2"
       shift 2
       ;;
-    --platform)
+    --cluster-type)
       if [[ $# -lt 2 ]]; then
-        echo "Error: --platform requires a value (kind or k3d)"
+        echo "Error: --cluster-type requires a value (kind or k3d)"
         exit 1
       fi
-      platform="$2"
+      cluster_type="$2"
       shift 2
       ;;
     *)
@@ -43,7 +43,7 @@ while [[ $# -gt 0 ]]; do
 done
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
-platform=${platform:-kind}
+cluster_type=${cluster_type:-kind}
 k3d_image=rancher/k3s:v1.32.13-k3s1
 
 :
@@ -51,14 +51,14 @@ k3d_image=rancher/k3s:v1.32.13-k3s1
 : Create the hosting cluster with ingress controller
 :
 
-if [ "$platform" == kind ]; then
+if [ "$cluster_type" == kind ]; then
 
     kind create cluster --name kubeflex --config ${SCRIPT_DIR}/kind-config.yaml
     kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/tags/controller-v1.12.1/deploy/static/provider/kind/deploy.yaml
     kubectl -n ingress-nginx patch deployment/ingress-nginx-controller --patch-file=${SCRIPT_DIR}/nginx-patch.yaml
     host_context=kind-kubeflex
 
-elif [ "$platform" == k3d ]; then
+elif [ "$cluster_type" == k3d ]; then
 
     k3d cluster create --image "$k3d_image" -p "9443:443@loadbalancer" --k3s-arg "--disable=traefik@server:*" kubeflex
     kubectl wait --for=condition=Ready node --all --timeout=600s
@@ -66,7 +66,7 @@ elif [ "$platform" == k3d ]; then
     host_context=k3d-kubeflex
 
 else
-    echo "$0: Invalid --platform; must be 'kind' or 'k3d'" >&2
+    echo "$0: Invalid --cluster-type; must be 'kind' or 'k3d'" >&2
     exit 1
 fi
 
@@ -90,7 +90,7 @@ if [[ -z "${release}" ]]; then
     : Load the local image into host cluster, re-generate manifests and helm chart, and install the helm chart:
     :
     :
-    make install-local-chart TEST_HOST="$platform"
+    make install-local-chart TEST_HOST="$cluster_type"
     :
     :
 else

--- a/test/e2e/setup-kubeflex.sh
+++ b/test/e2e/setup-kubeflex.sh
@@ -16,6 +16,7 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 release=""
+cluster_type="kind"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --release)
@@ -26,8 +27,20 @@ while [[ $# -gt 0 ]]; do
       release="$2"
       shift 2
       ;;
+    --cluster-type)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --cluster-type requires a value (kind or k3d)" >&2
+        exit 1
+      fi
+      cluster_type="$2"
+      if [[ "${cluster_type}" != "kind" && "${cluster_type}" != "k3d" ]]; then
+        echo "Error: --cluster-type must be 'kind' or 'k3d', got '${cluster_type}'" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
     *)
-      echo "Unknown argument: $1"
+      echo "Unknown argument: $1" >&2
       exit 1
       ;;
   esac
@@ -36,11 +49,21 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 :
 : -------------------------------------------------------------------------
-: Create the hosting kind cluster with ingress controller
+: Create the hosting cluster with ingress controller
 :
 
-kind create cluster --name kubeflex --config ${SCRIPT_DIR}/kind-config.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/tags/controller-v1.12.1/deploy/static/provider/kind/deploy.yaml
+if [[ "${cluster_type}" == "k3d" ]]; then
+    # Port mapping (-p 9080:80, -p 9443:443) intentionally mirrors kind-config.yaml
+    # which maps hostPort 9080->80 and 9443->443 for consistent behavior across both cluster types.
+    k3d cluster create kubeflex --k3s-arg "--disable=traefik@server:0" -p "9080:80@loadbalancer" -p "9443:443@loadbalancer"
+    kubectl config rename-context k3d-kubeflex kind-kubeflex || true
+    kubectl label node --all ingress-ready=true --overwrite
+    # Use the cloud/generic manifest which works on k3d (no kind-specific host paths)
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/tags/controller-v1.12.1/deploy/static/provider/cloud/deploy.yaml
+else
+    kind create cluster --name kubeflex --config ${SCRIPT_DIR}/kind-config.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/tags/controller-v1.12.1/deploy/static/provider/kind/deploy.yaml
+fi
 kubectl -n ingress-nginx patch deployment/ingress-nginx-controller --patch-file=${SCRIPT_DIR}/nginx-patch.yaml
 
 :

--- a/test/e2e/setup-kubeflex.sh
+++ b/test/e2e/setup-kubeflex.sh
@@ -16,7 +16,7 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 release=""
-cluster_type="kind"
+platform=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --release)
@@ -27,44 +27,48 @@ while [[ $# -gt 0 ]]; do
       release="$2"
       shift 2
       ;;
-    --cluster-type)
+    --platform)
       if [[ $# -lt 2 ]]; then
-        echo "Error: --cluster-type requires a value (kind or k3d)" >&2
+        echo "Error: --platform requires a value (kind or k3d)"
         exit 1
       fi
-      cluster_type="$2"
-      if [[ "${cluster_type}" != "kind" && "${cluster_type}" != "k3d" ]]; then
-        echo "Error: --cluster-type must be 'kind' or 'k3d', got '${cluster_type}'" >&2
-        exit 1
-      fi
+      platform="$2"
       shift 2
       ;;
     *)
-      echo "Unknown argument: $1" >&2
+      echo "Unknown argument: $1"
       exit 1
       ;;
   esac
 done
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
+platform=${platform:-kind}
+k3d_image=rancher/k3s:v1.32.13-k3s1
+
 :
 : -------------------------------------------------------------------------
 : Create the hosting cluster with ingress controller
 :
 
-if [[ "${cluster_type}" == "k3d" ]]; then
-    # Port mapping (-p 9080:80, -p 9443:443) intentionally mirrors kind-config.yaml
-    # which maps hostPort 9080->80 and 9443->443 for consistent behavior across both cluster types.
-    k3d cluster create kubeflex --k3s-arg "--disable=traefik@server:0" -p "9080:80@loadbalancer" -p "9443:443@loadbalancer"
-    kubectl config rename-context k3d-kubeflex kind-kubeflex || true
-    kubectl label node --all ingress-ready=true --overwrite
-    # Use the cloud/generic manifest which works on k3d (no kind-specific host paths)
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/tags/controller-v1.12.1/deploy/static/provider/cloud/deploy.yaml
-else
+if [ "$platform" == kind ]; then
+
     kind create cluster --name kubeflex --config ${SCRIPT_DIR}/kind-config.yaml
     kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/tags/controller-v1.12.1/deploy/static/provider/kind/deploy.yaml
+    kubectl -n ingress-nginx patch deployment/ingress-nginx-controller --patch-file=${SCRIPT_DIR}/nginx-patch.yaml
+    host_context=kind-kubeflex
+
+elif [ "$platform" == k3d ]; then
+
+    k3d cluster create --image "$k3d_image" -p "9443:443@loadbalancer" --k3s-arg "--disable=traefik@server:*" kubeflex
+    kubectl wait --for=condition=Ready node --all --timeout=600s
+    helm install ingress-nginx ingress-nginx --set "controller.extraArgs.enable-ssl-passthrough=" --repo https://kubernetes.github.io/ingress-nginx --version 4.12.1 --namespace ingress-nginx --create-namespace --timeout 24h
+    host_context=k3d-kubeflex
+
+else
+    echo "$0: Invalid --platform; must be 'kind' or 'k3d'" >&2
+    exit 1
 fi
-kubectl -n ingress-nginx patch deployment/ingress-nginx-controller --patch-file=${SCRIPT_DIR}/nginx-patch.yaml
 
 :
 : -------------------------------------------------------------------------
@@ -83,10 +87,10 @@ if [[ -z "${release}" ]]; then
 
     :
     : -------------------------------------------------------------------------
-    : Load the local image in kind, re-generate manifests and helm chart, and install the helm chart:
+    : Load the local image into host cluster, re-generate manifests and helm chart, and install the helm chart:
     :
     :
-    make install-local-chart
+    make install-local-chart TEST_HOST="$platform"
     :
     :
 else
@@ -102,7 +106,7 @@ else
 
         echo "Resolved latest release to ${release}"
     fi
-    
+
     # NOTE: v0.9.2 is known to be broken, but is still allowed for testing purposes
     if [[ "${release}" == "v0.9.2" ]]; then
         echo "WARNING: You are testing release v0.9.2, which is known to be broken."
@@ -130,7 +134,7 @@ fi
 : -------------------------------------------------------------------------
 : Create a PostCreateHook
 :
-kubectl --context kind-kubeflex apply -f - <<EOF
+kubectl --context $host_context apply -f - <<EOF
 apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
 kind: PostCreateHook
 metadata:

--- a/test/e2e/test-controller-image-update.sh
+++ b/test/e2e/test-controller-image-update.sh
@@ -18,8 +18,8 @@ set -e # exit on error
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --platform)
-      platform="$2"
+    --cluster-type)
+      cluster_type="$2"
       shift 2 ;;
     *)
       echo "Unknown argument: $1"
@@ -28,8 +28,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [ -z "$platform" ]; then
-    echo $0: Host platform must be defined, by '--platform' option or platform environment variable >&2
+if [ -z "$cluster_type" ]; then
+    echo $0: Cluster type must be defined, by '--cluster-type' option or cluster_type environment variable >&2
     exit 1
 fi
 
@@ -72,8 +72,8 @@ export IMAGE_TAG="e2e-test-$(date +%s)"
 echo "Using image tag: $IMAGE_TAG"
 
 # Run the make install-local-chart command
-echo "5. Running make install-local-chart TEST_HOST=$platform ..."
-make install-local-chart TEST_HOST="$platform"
+echo "5. Running make install-local-chart TEST_HOST=$cluster_type ..."
+make install-local-chart TEST_HOST="$cluster_type"
 
 # Wait for the deployment to update with proper timeout and status checking
 echo "6. Waiting for deployment to update..."

--- a/test/e2e/test-controller-image-update.sh
+++ b/test/e2e/test-controller-image-update.sh
@@ -16,6 +16,23 @@
 set -x # echo so that users can understand what is happening
 set -e # exit on error
 
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform)
+      platform="$2"
+      shift 2 ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$platform" ]; then
+    echo $0: Host platform must be defined, by '--platform' option or platform environment variable >&2
+    exit 1
+fi
+
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source "${SRC_DIR}/setup-shell.sh"
 
@@ -55,8 +72,8 @@ export IMAGE_TAG="e2e-test-$(date +%s)"
 echo "Using image tag: $IMAGE_TAG"
 
 # Run the make install-local-chart command
-echo "5. Running make install-local-chart..."
-make install-local-chart
+echo "5. Running make install-local-chart TEST_HOST=$platform ..."
+make install-local-chart TEST_HOST="$platform"
 
 # Wait for the deployment to update with proper timeout and status checking
 echo "6. Waiting for deployment to update..."

--- a/test/e2e/test-kubeconfig-access.sh
+++ b/test/e2e/test-kubeconfig-access.sh
@@ -26,6 +26,11 @@ while (( $# > 0 )); do
     then { CP_TYPE="$2"; shift 2; }
     else { echo "missing value for controlplane type" >&2; exit 1; }
     fi;;
+  (--host-context)
+    if (( $# > 1 ));
+    then { host_context="$2"; shift 2; }
+    else { echo "missing value for --host-context" >&2; exit 1; }
+    fi;;
   (-d|--debug)
     DEBUG=true
     shift;;
@@ -37,6 +42,11 @@ while (( $# > 0 )); do
     exit 1;;
   esac
 done
+
+if [ -z "$host_context" ]; then
+    echo $0: Host context must be defined, by '--host-context' option or host_context environment variable >&2
+    exit 1
+fi
 
 CP_NAME="kubeconfig-test-${CP_TYPE}"
 SRC_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
@@ -66,14 +76,14 @@ echo "Using secret: $SECRET_NAME with key: $SECRET_KEY for $CP_TYPE"
 : -------------------------------------------------------------------------
 : Clean up any existing resources
 :
-kubectl --context kind-kubeflex delete controlplane ${CP_NAME} --ignore-not-found=true
-kubectl --context kind-kubeflex delete postcreatehook kubeconfig-test-${CP_TYPE} --ignore-not-found=true
+kubectl --context "$host_context" delete controlplane ${CP_NAME} --ignore-not-found=true
+kubectl --context "$host_context" delete postcreatehook kubeconfig-test-${CP_TYPE} --ignore-not-found=true
 
 :
 : -------------------------------------------------------------------------
 : Create PostCreateHook that tests kubeconfig access
 :
-kubectl --context kind-kubeflex apply -f - <<EOF
+kubectl --context "$host_context" apply -f - <<EOF
 apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
 kind: PostCreateHook
 metadata:
@@ -107,7 +117,7 @@ EOF
 : Create ControlPlane with kubeconfig test PostCreateHook
 :
 echo "Creating ${CP_TYPE} ControlPlane..."
-kubectl --context kind-kubeflex apply -f - <<EOF
+kubectl --context "$host_context" apply -f - <<EOF
 apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
 kind: ControlPlane
 metadata:
@@ -124,21 +134,21 @@ EOF
 : Wait for ControlPlane to be ready
 :
 echo "Waiting for ${CP_TYPE} ControlPlane to be ready..."
-kubectl --context kind-kubeflex wait --for=condition=Ready controlplane/${CP_NAME} --timeout=600s
+kubectl --context "$host_context" wait --for=condition=Ready controlplane/${CP_NAME} --timeout=600s
 
 :
 : -------------------------------------------------------------------------
 : Verify PostCreateHook Job completed successfully
 :
-kubectl --context kind-kubeflex wait --for=condition=Complete job/validation-${CP_NAME} -n ${CP_NAME}-system --timeout=150s
+kubectl --context "$host_context" wait --for=condition=Complete job/validation-${CP_NAME} -n ${CP_NAME}-system --timeout=150s
 
 if [[ "$DEBUG" != "true" ]]; then
   :
   : -------------------------------------------------------------------------
   : Clean up any existing resources
   :
-  kubectl --context kind-kubeflex delete controlplane ${CP_NAME} --ignore-not-found=true
-  kubectl --context kind-kubeflex delete postcreatehook kubeconfig-test-${CP_TYPE} --ignore-not-found=true
+  kubectl --context "$host_context" delete controlplane ${CP_NAME} --ignore-not-found=true
+  kubectl --context "$host_context" delete postcreatehook kubeconfig-test-${CP_TYPE} --ignore-not-found=true
 fi
 
 echo "SUCCESS: ${CP_TYPE} PostCreateHook kubeconfig access test completed"


### PR DESCRIPTION
## Summary

This PR introduces the ability to run KubeFlex end-to-end tests against `k3d` clusters, addressing the need for robust testing on the most prominent KubeFlex user environment and preventing regressions from newer k3d releases.

Key changes:
- **E2E Scripts**: Updated `setup-kubeflex.sh`, `run.sh`, and `manage-type-external.sh` to accept a `--cluster-type` argument. This handles spinning up k3d clusters with disabled default traefik providers, custom port mappings, `ingress-ready=true` node labeling, and dynamic Docker networking.
- **Context Management**: Automatically renames k3d contexts to `kind-kubeflex` during setup to maintain backwards compatibility with all downstream testing scripts.
- **Cleanup**: Ensured `cleanup.sh` removes orphaned k3d clusters alongside kind clusters.
- **Image Loading**: Refactored the local testing targets in `Makefile` to dynamically detect whether a `kind` or `k3d` cluster is running, utilizing `k3d image import` instead of `kind load docker-image` when appropriate.
- **CI/CD Integration**: Updated `.github/workflows/test-e2e.yml` to utilize a build matrix strategy, actively running and validating control-plane lifecycle management across both `kind` and `k3d` cluster types.

## Related issue(s)

Fixes #682 